### PR TITLE
fix: tsconfig parsing error in eslintrc

### DIFF
--- a/web/crux/.eslintrc.js
+++ b/web/crux/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint/eslint-plugin'],


### PR DESCRIPTION
Problem: The error `Parsing error: Cannot read file '.../tsconfig.json'.eslint` shows in all .ts files in the src folder including index.ts.

By default, the projects (in parserOptions) are resolved relative to the current working directory. If you run `eslint` in a different working directory to the folder containing tsconfig.json, @typescript-eslint/parser will not be able to locate the file. The fix is to set a `tsconfigRootDir` to `__dirname`, which would make the parser resolve the project configuration relative to `.eslintrc.js`

Related: https://stackoverflow.com/questions/64933543/parsing-error-cannot-read-file-tsconfig-json-eslint