### PR TITLE
fix: json editor scrolling

### DIFF
--- a/web/crux-ui/src/components/notifications/edit-notification-card.tsx
+++ b/web/crux-ui/src/components/notifications/edit-notification-card.tsx
@@ -7,7 +7,7 @@ import { DyoInput } from '@app/elements/dyo-input'
 import { DyoLabel } from '@app/elements/dyo-label'
 import { DyoSwitch } from '@app/elements/dyo-switch'
 import { defaultApiErrorHandler } from '@app/errors'
-import { useThrottleing } from '@app/hooks/use-throttleing'
+import { useThrottling } from '@app/hooks/use-throttleing'
 import {
   CreateNotification,
   NotificationDetails,
@@ -45,7 +45,7 @@ const EditNotificationCard = (props: EditNotificationCardProps) => {
     },
   )
 
-  const throttle = useThrottleing(WEBOOK_TEST_DELAY)
+  const throttle = useThrottling(WEBOOK_TEST_DELAY)
 
   const editMode = !!notification.id
 

--- a/web/crux-ui/src/components/products/versions/deployments/deployment-details-section.tsx
+++ b/web/crux-ui/src/components/products/versions/deployments/deployment-details-section.tsx
@@ -1,6 +1,6 @@
 import KeyValueInput from '@app/components/shared/key-value-input'
 import { DEPLOYMENT_EDIT_WS_REQUEST_DELAY } from '@app/const'
-import { useThrottleing } from '@app/hooks/use-throttleing'
+import { useThrottling } from '@app/hooks/use-throttleing'
 import { deploymentIsMutable, DeploymentRoot, Environment, WS_TYPE_PATCH_DEPLOYMENT_ENV } from '@app/models'
 import { WebSocketEndpoint } from '@app/websockets/client'
 import useTranslation from 'next-translate/useTranslation'
@@ -18,7 +18,7 @@ const DeploymentDetailsSection = (props: DeploymentDetailsSectionProps) => {
 
   const mutable = deploymentIsMutable(deployment.status)
 
-  const throttle = useThrottleing(DEPLOYMENT_EDIT_WS_REQUEST_DELAY)
+  const throttle = useThrottling(DEPLOYMENT_EDIT_WS_REQUEST_DELAY)
 
   const onEnvChange = (env: Environment) => throttle(() => sock.send(WS_TYPE_PATCH_DEPLOYMENT_ENV, env))
   return (

--- a/web/crux-ui/src/components/products/versions/images/edit-image-config.tsx
+++ b/web/crux-ui/src/components/products/versions/images/edit-image-config.tsx
@@ -1,6 +1,6 @@
 import { IMAGE_WS_REQUEST_DELAY } from '@app/const'
 import { DyoInput } from '@app/elements/dyo-input'
-import { useThrottleing } from '@app/hooks/use-throttleing'
+import { useThrottling } from '@app/hooks/use-throttleing'
 import { ContainerConfig, Environment } from '@app/models'
 import useTranslation from 'next-translate/useTranslation'
 import { useEffect, useRef, useState } from 'react'
@@ -21,7 +21,7 @@ const EditImageConfig = (props: EditImageConfigProps) => {
   const patch = useRef<Partial<ContainerConfig>>({})
   const [containerName, setContainerName] = useState(config?.name)
 
-  const throttle = useThrottleing(IMAGE_WS_REQUEST_DELAY)
+  const throttle = useThrottling(IMAGE_WS_REQUEST_DELAY)
 
   const sendPatch = (config: Partial<ContainerConfig>) => {
     const newPatch = {

--- a/web/crux-ui/src/components/products/versions/images/edit-image-json.tsx
+++ b/web/crux-ui/src/components/products/versions/images/edit-image-json.tsx
@@ -1,6 +1,6 @@
 import JsonEditor from '@app/components/shared/json-editor-dynamic-module'
 import { IMAGE_WS_REQUEST_DELAY } from '@app/const'
-import { useThrottleing } from '@app/hooks/use-throttleing'
+import { CANCEL_THROTTLE, useThrottling } from '@app/hooks/use-throttleing'
 import { CompleteContainerConfig, ContainerConfig, UniqueKeyValue } from '@app/models'
 import { fold } from '@app/utils'
 import { completeContainerConfigSchema } from '@app/validation'
@@ -18,7 +18,7 @@ interface EditImageJsonProps {
 }
 
 const EditImageJson = (props: EditImageJsonProps) => {
-  const throttle = useThrottleing(IMAGE_WS_REQUEST_DELAY)
+  const throttle = useThrottling(IMAGE_WS_REQUEST_DELAY)
 
   const [state, dispatch] = useReducer(reducer, imageConfigToCompleteContainerConfig(null, props.config))
 
@@ -45,8 +45,7 @@ const EditImageJson = (props: EditImageJsonProps) => {
 
   const onParseError = useCallback(
     (err: Error) => {
-      // TODO @m8 why is this arrow function is empty?
-      throttle(() => {})
+      throttle(CANCEL_THROTTLE)
 
       props.onParseError(err)
     },
@@ -68,7 +67,7 @@ const EditImageJson = (props: EditImageJsonProps) => {
 
   return (
     <JsonEditor
-      className={clsx('flex flex-col flex-grow h-128', props.className)}
+      className={clsx('h-128 overflow-y-auto', props.className)}
       disabled={props.disabled}
       value={state}
       onChange={onChange}

--- a/web/crux-ui/src/components/products/versions/images/select-images-card.tsx
+++ b/web/crux-ui/src/components/products/versions/images/select-images-card.tsx
@@ -8,7 +8,7 @@ import { DyoInput } from '@app/elements/dyo-input'
 import { DyoLabel } from '@app/elements/dyo-label'
 import { DyoList } from '@app/elements/dyo-list'
 import LoadingIndicator from '@app/elements/loading-indicator'
-import { useThrottleing } from '@app/hooks/use-throttleing'
+import { useThrottling } from '@app/hooks/use-throttleing'
 import { useWebSocket } from '@app/hooks/use-websocket'
 import {
   FindImageMessage,
@@ -42,7 +42,7 @@ const SelectImagesCard = (props: SelectImagesCardProps) => {
   const [selected, setSelected] = useState<SelectableImage[]>([])
   const [images, setImages] = useState<SelectableImage[]>([])
   const [filter, setFilter] = useState('')
-  const throttleFilter = useThrottleing(IMAGE_WS_REQUEST_DELAY)
+  const throttleFilter = useThrottling(IMAGE_WS_REQUEST_DELAY)
 
   const registriesFound = registries?.length > 0
 

--- a/web/crux-ui/src/components/shared/json-editor.tsx
+++ b/web/crux-ui/src/components/shared/json-editor.tsx
@@ -39,17 +39,17 @@ const _JsonEditor = <T,>(props: JsonEditorProps<T>) => {
   }
 
   return (
-    <Editor
-      disabled={props.disabled}
-      preClassName={props.className}
-      className={clsx('text-white bg-gray-900 rounded-md ring-2 ring-light-grey border-dark')}
-      padding={2}
-      tabSize={2}
-      insertSpaces
-      value={state}
-      onValueChange={onChange}
-      highlight={value => highlight(value, languages['json'], 'json')}
-    />
+    <div className={clsx('bg-gray-900 rounded-md ring-2 ring-light-grey border-dark', props.className)}>
+      <Editor
+        disabled={props.disabled}
+        padding={2}
+        tabSize={2}
+        insertSpaces
+        value={state}
+        onValueChange={onChange}
+        highlight={value => highlight(value, languages['json'], 'json')}
+      />
+    </div>
   )
 }
 

--- a/web/crux-ui/src/hooks/use-throttleing.ts
+++ b/web/crux-ui/src/hooks/use-throttleing.ts
@@ -4,7 +4,9 @@ type ThrottledAction = {
   trigger: VoidFunction
 }
 
-export const useThrottleing = (delay: number): ((action: VoidFunction) => void) => {
+export const CANCEL_THROTTLE = () => {}
+
+export const useThrottling = (delay: number): ((action: VoidFunction) => void) => {
   const [action, setAction] = useState<ThrottledAction>()
   const schedule = useRef<NodeJS.Timeout>()
 

--- a/web/crux-ui/src/pages/audit-log.tsx
+++ b/web/crux-ui/src/pages/audit-log.tsx
@@ -136,11 +136,7 @@ const AuditLogPage = (props: AuditLogPageProps) => {
           onClose={() => setShowInfo(null)}
         >
           <span className="text-bright font-semibold">{beautifyAuditLogEvent(showInfo.event)}</span>
-          <JsonEditor
-            className="text-bright mt-8 overflow-y-auto h-full !pointer-events-auto"
-            disabled
-            value={parsedJSONInfo}
-          />
+          <JsonEditor className="overflow-y-auto mt-8" disabled value={parsedJSONInfo} />
         </DyoModal>
       )}
     </Layout>


### PR DESCRIPTION
Now json editor is scrolling vertically just fine when the config is too large for 128 rem