### PR TITLE
fix(crux-ui): node edit after save

### DIFF
--- a/web/crux-ui/src/components/nodes/dyo-node-setup.tsx
+++ b/web/crux-ui/src/components/nodes/dyo-node-setup.tsx
@@ -37,6 +37,10 @@ const DyoNodeSetup = (props: DyoNodeSetupProps) => {
   const handleApiError = defaultApiErrorHandler(t)
 
   const onGenerateInstallScript = async () => {
+    if (remaining > 0) {
+      cancelCountdown()
+    }
+
     const body = {
       type: node.type,
     }

--- a/web/crux-ui/src/components/nodes/edit-node-card.tsx
+++ b/web/crux-ui/src/components/nodes/edit-node-card.tsx
@@ -140,8 +140,25 @@ const EditNodeCard = (props: EditNodeCardProps) => {
         } else {
           result = {
             ...values,
+            id: node.id,
             status: node.status,
+            type: node.type,
           } as DyoNodeDetails
+
+          if (values.name !== node.name) {
+            const revokeScript = await fetch(nodeTokenApiUrl(node.id), {
+              method: 'DELETE',
+            })
+
+            if (revokeScript.ok) {
+              result = {
+                ...result,
+                hasToken: false,
+                install: null,
+                type: node.type,
+              }
+            }
+          }
         }
 
         setNode(result)

--- a/web/crux/src/app/agent/agent.service.ts
+++ b/web/crux/src/app/agent/agent.service.ts
@@ -84,7 +84,7 @@ export class AgentService {
 
   async install(nodeId: string, nodeType: NodeTypeEnum): Promise<AgentInstaller> {
     let installer = this.getInstallerByNodeId(nodeId)
-    if (!installer) {
+    if (!installer || installer.nodeType !== nodeType) {
       const now = new Date().getTime()
 
       const token: AgentToken = {


### PR DESCRIPTION
After saving a new node you can edit it immediately and the node list stays up to date. You only have to regenerate your script if the node's name changed.