### PR TITLE
fix(crux-ui): active menu and paddings fixes

### DIFF
--- a/web/crux-ui/locales/en/versions.json
+++ b/web/crux-ui/locales/en/versions.json
@@ -5,7 +5,7 @@
   "increaseTips": "By increasing the version of your Product, you're able to create new releases of your already existing Product with new images or substitute included ones with a different tag.",
   "new": "New version",
   "default": "Default",
-  "changelog": "Changelog",  
+  "changelog": "Changelog",
   "type": "Type",
   "incremental": "Incremental",
   "rolling": "Rolling",

--- a/web/crux-ui/src/components/layout.tsx
+++ b/web/crux-ui/src/components/layout.tsx
@@ -12,7 +12,7 @@ import Footer from './main/footer'
 import { Sidebar } from './main/sidebar'
 import Topbar from './main/top-bar'
 
-const sidebarWidth = 'w-[20rem]'
+const sidebarWidth = 'w-[17rem]'
 const mainWidth = 'w-[calc(100vw-20rem)]' // ViewWidth - sidebar
 
 interface PageHeadProps {

--- a/web/crux-ui/src/components/main/nav-button.tsx
+++ b/web/crux-ui/src/components/main/nav-button.tsx
@@ -14,7 +14,7 @@ const NavButton = (props: NavButtonProps) => {
 
   const router = useRouter()
 
-  const isActive = router.pathname === href
+  const isActive = router.pathname.startsWith(href)
 
   return (
     <>

--- a/web/crux-ui/src/components/main/sidebar.tsx
+++ b/web/crux-ui/src/components/main/sidebar.tsx
@@ -87,8 +87,8 @@ export const Sidebar = (props: SidebarProps) => {
               className="cursor-pointer"
               src="/dyrector_io_logo_white.svg"
               alt={t('dyoWhiteLogo')}
-              width={200}
-              height={80}
+              width={160}
+              height={64}
             />
           </a>
         </Link>

--- a/web/crux-ui/src/components/products/versions/version-deployments-section.tsx
+++ b/web/crux-ui/src/components/products/versions/version-deployments-section.tsx
@@ -84,7 +84,9 @@ const VersionDeploymentsSection = (props: VersionDeploymentsSectionProps) => {
     router.push(deploymentDeployUrl(product.id, version.id, deployment.id))
 
   const headers = [
-    ...['deploymentName', 'common:node', 'common:prefix', 'common:status', 'common:date', 'common:actions'].map(it => t(it)),
+    ...['deploymentName', 'common:node', 'common:prefix', 'common:status', 'common:date', 'common:actions'].map(it =>
+      t(it),
+    ),
   ]
   const defaultHeaderClass = 'h-11 uppercase text-bright text-sm bg-medium-eased py-3 pl-4 font-semibold'
   const headerClasses = [

--- a/web/crux-ui/src/components/products/versions/version-deployments-section.tsx
+++ b/web/crux-ui/src/components/products/versions/version-deployments-section.tsx
@@ -84,7 +84,7 @@ const VersionDeploymentsSection = (props: VersionDeploymentsSectionProps) => {
     router.push(deploymentDeployUrl(product.id, version.id, deployment.id))
 
   const headers = [
-    ...['deploymentName', 'common:node', 'common:prefix', 'common:status', 'common:date', 'actions'].map(it => t(it)),
+    ...['deploymentName', 'common:node', 'common:prefix', 'common:status', 'common:date', 'common:actions'].map(it => t(it)),
   ]
   const defaultHeaderClass = 'h-11 uppercase text-bright text-sm bg-medium-eased py-3 pl-4 font-semibold'
   const headerClasses = [

--- a/web/crux-ui/src/elements/dyo-expandable-text.tsx
+++ b/web/crux-ui/src/elements/dyo-expandable-text.tsx
@@ -26,7 +26,10 @@ const DyoExpandableText = (props: DyoExpandableTextProps) => {
 
   return (
     <>
-      <p ref={overflowRef} className={clsx(className, lineClamp[propsLineClamp - 1], 'break-all', overflow ? null : 'mb-8')}>
+      <p
+        ref={overflowRef}
+        className={clsx(className, lineClamp[propsLineClamp - 1], 'break-all', overflow ? null : 'mb-8')}
+      >
         {text}
       </p>
       {!overflow ? null : (

--- a/web/crux-ui/src/elements/dyo-expandable-text.tsx
+++ b/web/crux-ui/src/elements/dyo-expandable-text.tsx
@@ -26,7 +26,7 @@ const DyoExpandableText = (props: DyoExpandableTextProps) => {
 
   return (
     <>
-      <p ref={overflowRef} className={clsx(className, lineClamp[propsLineClamp - 1], 'break-all')}>
+      <p ref={overflowRef} className={clsx(className, lineClamp[propsLineClamp - 1], 'break-all', overflow ? null : 'mb-8')}>
         {text}
       </p>
       {!overflow ? null : (


### PR DESCRIPTION
PR contains the followings:

- fix the active menu
- add padding in the version changelog when it's not too long
- add missing i18n
- format 