### PR TITLE
fix(agent): use regex on container listing

### DIFF
--- a/agent/pkg/dagent/utils/docker.go
+++ b/agent/pkg/dagent/utils/docker.go
@@ -82,7 +82,7 @@ func GetContainersByName(name string) []types.Container {
 
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
 		All:     true,
-		Filters: filters.NewArgs(filters.KeyValuePair{Key: "name", Value: name}),
+		Filters: filters.NewArgs(filters.KeyValuePair{Key: "name", Value: fmt.Sprintf("^/?%s-", name)}),
 	})
 
 	checkDockerError(err)


### PR DESCRIPTION
The previous version checked whether the container name contains the prefix or not. It lead to see containers which is contained the prefix but not necessary started with it.