### PR TITLE
fix(agent): fix create network

### DIFF
--- a/agent/pkg/builder/container/container_builder.go
+++ b/agent/pkg/builder/container/container_builder.go
@@ -424,7 +424,7 @@ func prepareImage(dc *DockerContainerBuilder) error {
 }
 
 func createNetworks(dc *DockerContainerBuilder) []string {
-	var networkIDs []string
+	networkIDs := []string{}
 
 	for _, networkName := range dc.networks {
 		filter := filters.NewArgs()


### PR DESCRIPTION
The deployment failed if you didn't provide any network information in the config.