### PR TITLE
fix(web): deployment improvements

### DIFF
--- a/web/crux-ui/locales/en/versions.json
+++ b/web/crux-ui/locales/en/versions.json
@@ -27,5 +27,6 @@
   "addDeployment": "Add deployment",
   "addImage": "Add image",
 
-  "deploymentName": "Deployment name"
+  "deploymentName": "Deployment name",
+  "alreadyHavePreparing": "You already have one preparing deployment!"
 }

--- a/web/crux-ui/package-lock.json
+++ b/web/crux-ui/package-lock.json
@@ -23,6 +23,7 @@
         "next": "^12.2.4",
         "next-translate": "1.6.0-canary.1",
         "node-fetch": "^2.6.6",
+        "openpgp": "^5.4.0",
         "prismjs": "^1.28.0",
         "react": "^17.0.2",
         "react-datepicker": "^4.8.0",
@@ -62,7 +63,6 @@
         "eslint-plugin-react-hooks": "^4.3.0",
         "grpc_tools_node_protoc_ts": "^5.3.2",
         "grpc-tools": "^1.11.2",
-        "openpgp": "^5.4.0",
         "postcss": "^8.4.12",
         "prettier": "^2.5.1",
         "prettier-plugin-organize-imports": "^2.3.4",
@@ -1181,7 +1181,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
       "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "dev": true,
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -1306,8 +1305,7 @@
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3117,8 +3115,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -3604,8 +3601,7 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3958,7 +3954,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.4.0.tgz",
       "integrity": "sha512-XgQnK8SYy4Ycg9BDvrXTE4foMwME/+1EfGZWZirUU2VPzU1X3xx094fChjbP10+gUJifAcoWTsT2zAbdhFUxyg==",
-      "dev": true,
       "dependencies": {
         "asn1.js": "^5.0.0"
       },
@@ -4667,8 +4662,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
@@ -6196,7 +6190,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
       "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -6279,8 +6272,7 @@
     "bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -7606,8 +7598,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -7966,8 +7957,7 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.1.2",
@@ -8208,7 +8198,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.4.0.tgz",
       "integrity": "sha512-XgQnK8SYy4Ycg9BDvrXTE4foMwME/+1EfGZWZirUU2VPzU1X3xx094fChjbP10+gUJifAcoWTsT2zAbdhFUxyg==",
-      "dev": true,
       "requires": {
         "asn1.js": "^5.0.0"
       }
@@ -8655,8 +8644,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "scheduler": {
       "version": "0.20.2",

--- a/web/crux-ui/src/components/nodes/dyo-node-card.tsx
+++ b/web/crux-ui/src/components/nodes/dyo-node-card.tsx
@@ -22,7 +22,10 @@ const DyoNodeCard = (props: DyoNodeCardProps) => {
       <div className={clsx(onNameClick ? 'cursor-pointer' : null, 'flex flex-row')} onClick={onNameClick}>
         {node.icon ? <DyoBadge icon={node.icon} /> : null}
 
-        <DyoHeading className="text-xl text-bright font-semibold ml-4 my-auto mr-auto" element="h3">
+        <DyoHeading
+          className={clsx('text-xl text-bright font-semibold my-auto mr-auto', node.icon ? 'ml-4' : null)}
+          element="h3"
+        >
           {node.name}
         </DyoHeading>
 

--- a/web/crux-ui/src/components/products/versions/deployments/add-deployment-card.tsx
+++ b/web/crux-ui/src/components/products/versions/deployments/add-deployment-card.tsx
@@ -13,6 +13,7 @@ import { fetcher, sendForm } from '@app/utils'
 import { createDeploymentSchema } from '@app/validation'
 import { useFormik } from 'formik'
 import useTranslation from 'next-translate/useTranslation'
+import toast from 'react-hot-toast'
 import useSWR from 'swr'
 
 interface AddDeploymentCardProps {
@@ -54,6 +55,7 @@ const AddDeploymentCard = (props: AddDeploymentCardProps) => {
         onAdd(result.id)
       } else if (res.status === 409) {
         // There is already a deployment for the selected node
+        toast.error(t('alreadyHavePreparing'))
         const dto = (await res.json()) as DyoApiError
         onAdd(dto.value)
       } else {

--- a/web/crux-ui/src/websockets/websocket-client-endpoint.ts
+++ b/web/crux-ui/src/websockets/websocket-client-endpoint.ts
@@ -58,6 +58,10 @@ class WebSocketClientEndpoint {
   onOpen(sendClientMessage: WebSocketClientSendMessage): void {
     this.sendClientMessage = sendClientMessage
 
+    if (this.readyStateChanged) {
+      this.readyStateChanged(WebSocket.OPEN)
+    }
+
     if (this.options?.onOpen) {
       this.options.onOpen()
     }
@@ -68,6 +72,10 @@ class WebSocketClientEndpoint {
   onClose() {
     if (this.options?.onClose) {
       this.options.onClose()
+    }
+
+    if (this.readyStateChanged) {
+      this.readyStateChanged(WebSocket.CLOSED)
     }
   }
 


### PR DESCRIPTION
PR contains the following:

- Added an error toast to the create deployment screen which applies if the user wants to create more than one preparing deployment
- Fixed the issue when after you made a successful deployment the previous ones were not moved to obsolate status
- Fixed the issue when you were getting toast errors after making two simple product deployments each after