### PR TITLE
feat(crux-ui): add node status filter

### DIFF
--- a/web/crux-ui/locales/en/nodes.json
+++ b/web/crux-ui/locales/en/nodes.json
@@ -33,5 +33,10 @@
   "technologies": {
     "docker": "Docker Host",
     "k8s": "Kubernetes Cluster"
+  },
+  "statusFilters": {
+    "all": "All",
+    "active": "Active",
+    "inactive": "Inactive"
   }
 }

--- a/web/crux-ui/locales/en/versions.json
+++ b/web/crux-ui/locales/en/versions.json
@@ -28,5 +28,6 @@
   "addImage": "Add image",
 
   "deploymentName": "Deployment name",
-  "alreadyHavePreparing": "You already have one preparing deployment!"
+  "alreadyHavePreparing": "You already have one preparing deployment!",
+  "nodeRequired": "You can't create deployment without having at least one node!"
 }

--- a/web/crux-ui/src/components/products/versions/deployments/add-deployment-card.tsx
+++ b/web/crux-ui/src/components/products/versions/deployments/add-deployment-card.tsx
@@ -13,6 +13,7 @@ import { fetcher, sendForm } from '@app/utils'
 import { createDeploymentSchema } from '@app/validation'
 import { useFormik } from 'formik'
 import useTranslation from 'next-translate/useTranslation'
+import { useEffect } from 'react'
 import toast from 'react-hot-toast'
 import useSWR from 'swr'
 
@@ -30,6 +31,12 @@ const AddDeploymentCard = (props: AddDeploymentCardProps) => {
   const { t } = useTranslation('versions')
 
   const { data: nodes, error: fetchNodesError } = useSWR<DyoNode[]>(API_NODES, fetcher)
+
+  useEffect(() => {
+    if (nodes && nodes.length < 1) {
+      toast.error(t('nodeRequired'))
+    }
+  }, [nodes, t])
 
   const handleApiError = defaultApiErrorHandler(t)
 

--- a/web/crux-ui/src/components/registries/registry-fields/v2-registry-field.tsx
+++ b/web/crux-ui/src/components/registries/registry-fields/v2-registry-field.tsx
@@ -29,7 +29,7 @@ const V2RegistryFields = (props: EditRegistryTypeProps<V2RegistryDetails>) => {
         <DyoToggle
           className="text-bright mt-8"
           name="isPrivate"
-          nameChecked={t('isPrivate')}
+          nameChecked={t('private')}
           nameUnchecked={t('public')}
           checked={formik.values.isPrivate}
           setFieldValue={(field: string, value: boolean, shouldValidate?: boolean | undefined) => {

--- a/web/crux-ui/src/components/shared/filters.tsx
+++ b/web/crux-ui/src/components/shared/filters.tsx
@@ -1,16 +1,18 @@
 import { DyoCard } from '@app/elements/dyo-card'
 import { DyoHeading } from '@app/elements/dyo-heading'
 import { DyoInput } from '@app/elements/dyo-input'
+import clsx from 'clsx'
 import useTranslation from 'next-translate/useTranslation'
 import React from 'react'
 
 export interface FiltersProps {
   setTextFilter: (filter: string) => void
   children?: React.ReactNode
+  searchClassName?: string
 }
 
 const Filters = (props: FiltersProps) => {
-  const { setTextFilter: setFilter, children } = props
+  const { setTextFilter: setFilter, children, searchClassName } = props
 
   const { t } = useTranslation('common')
 
@@ -21,7 +23,12 @@ const Filters = (props: FiltersProps) => {
       </DyoHeading>
 
       <div className="flex items-center mt-4">
-        <DyoInput className="w-2/3" placeholder={t('common:search')} onChange={e => setFilter(e.target.value)} grow />
+        <DyoInput
+          className={clsx(searchClassName ?? 'w-2/3')}
+          placeholder={t('common:search')}
+          onChange={e => setFilter(e.target.value)}
+          grow
+        />
 
         {children}
       </div>


### PR DESCRIPTION
**Added a node status filter to node list screen.**

PR also contains additonaly the following:

- Fix missing localization on registry screen.
- Add a toast error to the add deployment screen which applies when the user has no nodes