### PR TITLE
fix(crux-ui): auditlog datefilter

### DIFF
--- a/web/crux-ui/src/pages/audit-log.tsx
+++ b/web/crux-ui/src/pages/audit-log.tsx
@@ -44,7 +44,7 @@ const AuditLogPage = (props: AuditLogPageProps) => {
     },
     filters: [
       textFilterFor<AuditLog>(it => [it.identityEmail, utcDateToLocale(it.date), it.event, it.info]),
-      dateRangeFilterFor<AuditLog>(it => [utcDateToLocale(it.date)]),
+      dateRangeFilterFor<AuditLog>(it => [it.date]),
     ],
   })
 


### PR DESCRIPTION
Fix for en-GB locale (dd/mm/yyyy format)