### PR TITLE
feat: add secret volume to k8s manifests

### DIFF
--- a/agent/manifest/kubernetes/deployment.yaml
+++ b/agent/manifest/kubernetes/deployment.yaml
@@ -29,3 +29,11 @@ spec:
           envFrom:
             - configMapRef:
                 name: crane-config
+          volumeMounts:
+            - name: agent-data
+              mountPath: /srv/dagent
+      volumes:
+      - name: agent-data
+        persistentVolumeClaim:
+          claimName: agent-data
+

--- a/agent/manifest/kubernetes/volume.yaml
+++ b/agent/manifest/kubernetes/volume.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agent-data
+  namespace: dyrectorio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/web/crux/install-k8s.sh.hbr
+++ b/web/crux/install-k8s.sh.hbr
@@ -21,8 +21,10 @@ EOF
 
 {{#if localManifests }}
 kubectl apply -f ./agent/manifest/kubernetes/rolebinding.yaml
+kubectl apply -f ./agent/manifest/kubernetes/volume.yaml
 kubectl apply -f ./agent/manifest/kubernetes/deployment.yaml
 {{else}}
 kubectl apply -f https://raw.githubusercontent.com/dyrector-io/dyrectorio/main/agent/manifest/kubernetes/rolebinding.yaml
+kubectl apply -f https://raw.githubusercontent.com/dyrector-io/dyrectorio/main/agent/manifest/kubernetes/volume.yaml
 kubectl apply -f https://raw.githubusercontent.com/dyrector-io/dyrectorio/main/agent/manifest/kubernetes/deployment.yaml
 {{/if }}


### PR DESCRIPTION
Recent changes to secret management and end-to-end encrypted secrets need us to allocate a volume in the cluster upon the installation of crane.