### PR TITLE
fix: deploying on unreachable node

### DIFF
--- a/web/crux-ui/src/pages/products/[productId]/versions/[versionId]/deployments/[deploymentId].tsx
+++ b/web/crux-ui/src/pages/products/[productId]/versions/[versionId]/deployments/[deploymentId].tsx
@@ -117,6 +117,11 @@ const DeploymentDetailsPage = (props: DeploymentDetailsPageProps) => {
   const onOpenLog = () => router.push(deploymentDeployUrl(product.id, version.id, deployment.id))
 
   const onDeploy = () => {
+    if (deployment.node.status !== 'running') {
+      toast.error(t('common:nodeUnreachable'))
+      return
+    }
+
     let error: ValidationError
 
     let i = 0


### PR DESCRIPTION
When clicking on the deploy button while the target node is unreachable, the app shows a toast now instead of navigation to the deploy page.