### PR TITLE
fix(web): restrict deployment creation without images

### DIFF
--- a/web/crux-ui/locales/en/versions.json
+++ b/web/crux-ui/locales/en/versions.json
@@ -31,5 +31,8 @@
   "alreadyHavePreparing": "You already have one preparing deployment!",
   "nodeRequired": "You can't create deployment without having at least one node!",
   "versionSemanticHint": "Version is not in semantic format.",
-  "emptyChangelog": "You have not provided any changes"
+  "emptyChangelog": "You have not provided any changes",
+  "errors": {
+    "preconditionFailed": "You can't create a deployment without having atleast one image"
+  }
 }

--- a/web/crux-ui/src/elements/dyo-button.tsx
+++ b/web/crux-ui/src/elements/dyo-button.tsx
@@ -53,6 +53,7 @@ const DyoButton = (props: DyoButtonProps) => {
   return (
     <button
       {...forwaredProps}
+      disabled={disabled}
       /* eslint-disable-next-line react/button-has-type */
       type={type ?? 'button'}
       className={clsx(

--- a/web/crux/src/app/deploy/pipes/deploy.create.pipe.ts
+++ b/web/crux/src/app/deploy/pipes/deploy.create.pipe.ts
@@ -1,6 +1,6 @@
 import { Injectable, PipeTransform } from '@nestjs/common'
 import PrismaService from 'src/services/prisma.service'
-import { AlreadyExistsException } from 'src/exception/errors'
+import { AlreadyExistsException, PreconditionFailedException } from 'src/exception/errors'
 import { CreateDeploymentRequest } from 'src/grpc/protobuf/proto/crux'
 
 @Injectable()
@@ -21,6 +21,20 @@ export default class DeployCreateValidationPipe implements PipeTransform {
         message: 'There is already a deployment with preparing status for the version on that node',
         property: 'deploymentId',
         value: deployments[0].id,
+      })
+    }
+
+    const images = await this.prisma.image.count({
+      where: {
+        versionId: value.versionId,
+      },
+    })
+
+    if (images < 1) {
+      throw new PreconditionFailedException({
+        message: 'There is no image to deploy',
+        property: 'versionId',
+        value: value.versionId,
       })
     }
 


### PR DESCRIPTION
Now you can't create deployment without having atleast one image.

PR also contains:
- fix disabled buttons