### PR TITLE
feat(web): use default container list on deployment screen

### DIFF
--- a/agent/internal/mapper/grpc.go
+++ b/agent/internal/mapper/grpc.go
@@ -342,7 +342,14 @@ func MapContainerState(in *[]dockerTypes.Container) []*common.ContainerStateItem
 
 		name := ""
 		if len(it.Names) > 0 {
-			name = it.Names[0]
+			const PARTS = 2
+			splitted := strings.SplitN(it.Names[0], "/", PARTS)
+
+			if len(splitted) == PARTS {
+				name = splitted[1]
+			} else {
+				name = it.Names[0]
+			}
 		}
 
 		imageName := strings.Split(it.Image, ":")

--- a/protobuf/proto/crux.proto
+++ b/protobuf/proto/crux.proto
@@ -83,7 +83,6 @@ service CruxDeployment {
   rpc GetSecrets(PrefixRequest) returns (common.ListSecretsResponse);
 
   rpc StartDeployment(IdRequest) returns (stream DeploymentProgressMessage);
-
   rpc SubscribeToDeploymentEditEvents(ServiceIdRequest)
       returns (stream DeploymentEditEventMessage);
 }

--- a/web/crux-ui/locales/en/common.json
+++ b/web/crux-ui/locales/en/common.json
@@ -92,7 +92,7 @@
   "secondsAgo": "{{seconds}} seconds ago",
   "minutesAgo": "{{minutes}} minutes ago",
   "hoursAgo": "{{hours}} hours ago",
-  "daysAgo": "{{days}} daysAgo",
+  "daysAgo": "{{days}} days ago",
   "dateFormat": "yyyy. MM. dd.",
 
   "key": "Key",
@@ -166,5 +166,6 @@
   "itemsPerPage": "Items per page",
   "showingItems": "Showing {{pageFrom}} to {{pageTo}} of {{total}} entries",
   "openSource": "is an Open Source project",
-  "cannotDefineSecretsHere": "Secret keys can be provided here, values can be set in deployments."
+  "cannotDefineSecretsHere": "Secret keys can be provided here, values can be set in deployments.",
+  "notFound": "Not Found"
 }

--- a/web/crux-ui/public/circle-bright.svg
+++ b/web/crux-ui/public/circle-bright.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="5.5" cy="5.5" r="5" fill="#D0D2D6"/>
+</svg>

--- a/web/crux-ui/src/components/nodes/container-status-indicator.tsx
+++ b/web/crux-ui/src/components/nodes/container-status-indicator.tsx
@@ -30,7 +30,12 @@ const ContainerStatusIndicator = (props: ContainerStatusIndicatorProps) => {
 
   return (
     <div className={clsx(className, 'flex')}>
-      <Image src={`/${statusToAssetName(status)}.svg`} alt={t(`containerStatuses.${status}`)} width={16} height={16} />
+      <Image
+        src={status ? `/${statusToAssetName(status)}.svg` : `/circle-bright.svg`}
+        alt={status ? t(`containerStatuses.${status}`) : t('notFound')}
+        width={16}
+        height={16}
+      />
     </div>
   )
 }

--- a/web/crux-ui/src/components/nodes/container-status-tag.tsx
+++ b/web/crux-ui/src/components/nodes/container-status-tag.tsx
@@ -1,5 +1,6 @@
 import DyoTag from '@app/elements/dyo-tag'
 import { ContainerState } from '@app/models'
+import useTranslation from 'next-translate/useTranslation'
 
 interface ContainerStatusTagProps {
   className?: string
@@ -8,6 +9,7 @@ interface ContainerStatusTagProps {
 
 const ContainerStatusTag = (props: ContainerStatusTagProps) => {
   const { state, className } = props
+  const { t } = useTranslation('common')
 
   const statusToBgColor = () => {
     switch (state) {
@@ -41,12 +43,12 @@ const ContainerStatusTag = (props: ContainerStatusTagProps) => {
 
   return (
     <DyoTag
-      color={statusToBgColor()}
-      textColor={statusToTextColor()}
+      color={state ? statusToBgColor() : 'bg-bright'}
+      textColor={state ? statusToTextColor() : 'text-bright'}
       className={className}
       solid={state === 'removing'}
     >
-      {state.toUpperCase()}
+      {state ? t(`containerStatuses.${state}`) : t('notFound')}
     </DyoTag>
   )
 }

--- a/web/crux/proto/crux.proto
+++ b/web/crux/proto/crux.proto
@@ -83,7 +83,6 @@ service CruxDeployment {
   rpc GetSecrets(PrefixRequest) returns (common.ListSecretsResponse);
 
   rpc StartDeployment(IdRequest) returns (stream DeploymentProgressMessage);
-
   rpc SubscribeToDeploymentEditEvents(ServiceIdRequest)
       returns (stream DeploymentEditEventMessage);
 }

--- a/web/crux/src/app/node/node.service.ts
+++ b/web/crux/src/app/node/node.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { Observable } from 'rxjs'
-import { PreconditionFailedException } from 'src/exception/errors'
 import {
   AccessRequest,
   ContainerStateListMessage,
@@ -21,6 +20,7 @@ import {
 import PrismaService from 'src/services/prisma.service'
 import DomainNotificationService from 'src/services/domain.notification.service'
 import { BaseMessage } from 'src/domain/notification-templates'
+import { PreconditionFailedException } from 'src/exception/errors'
 import AgentService from '../agent/agent.service'
 import TeamRepository from '../team/team.repository'
 import NodeMapper from './node.mapper'
@@ -179,6 +179,7 @@ export default class NodeService {
     this.logger.debug(`Opening container status channel for prefix: ${request.nodeId} - ${request.prefix}`)
 
     const agent = this.agentService.getById(request.nodeId)
+
     if (!agent) {
       throw new PreconditionFailedException({
         message: 'Node is unreachable',
@@ -186,6 +187,7 @@ export default class NodeService {
         value: request.nodeId,
       })
     }
+
     const prefix = request.prefix ?? ''
     const watcher = agent.upsertContainerStatusWatcher(prefix)
     return watcher.watch()


### PR DESCRIPTION
From now, on the deployment's log screen you can always see your containers (even if they are deleted). Previously when you started a deplyoment the container's list were uploaded continuously. Now only their status are updated. Also the prefix has been removed from the container's name in case of docker.