### PR TITLE
refactor(crux): use @updatedAt in prisma schema

### DIFF
--- a/web/crux/prisma/migrations/20220929162700_use_updated_at_attribute/migration.sql
+++ b/web/crux/prisma/migrations/20220929162700_use_updated_at_attribute/migration.sql
@@ -1,0 +1,26 @@
+-- AlterTable
+ALTER TABLE "Deployment" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Image" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Instance" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Node" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Notification" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Product" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Registry" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Team" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "Version" ALTER COLUMN "updatedAt" DROP DEFAULT;

--- a/web/crux/prisma/schema.prisma
+++ b/web/crux/prisma/schema.prisma
@@ -14,7 +14,7 @@ model Team {
   name      String    @unique @db.VarChar(70)
   createdAt DateTime  @default(now()) @db.Timestamptz(6)
   createdBy String    @db.Uuid
-  updatedAt DateTime? @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime? @updatedAt @db.Timestamptz(6)
   updatedBy String?   @db.Uuid
 
   registries    Registry[]
@@ -51,7 +51,7 @@ model Node {
   id             String        @id @default(uuid()) @db.Uuid
   createdAt      DateTime      @default(now()) @db.Timestamptz(6)
   createdBy      String        @db.Uuid
-  updatedAt      DateTime?     @default(now()) @db.Timestamptz(6)
+  updatedAt      DateTime?     @updatedAt @db.Timestamptz(6)
   updatedBy      String?       @db.Uuid
   name           String        @db.VarChar(70)
   type           NodeTypeEnum? @default(docker)
@@ -73,7 +73,7 @@ model Registry {
   id              String                 @id @default(uuid()) @db.Uuid
   createdAt       DateTime               @default(now()) @db.Timestamptz(6)
   createdBy       String                 @db.Uuid
-  updatedAt       DateTime?              @default(now()) @db.Timestamptz(6)
+  updatedAt       DateTime?              @updatedAt @db.Timestamptz(6)
   updatedBy       String?                @db.Uuid
   name            String                 @db.VarChar(70)
   description     String?
@@ -97,7 +97,7 @@ model Product {
   id          String          @id @default(uuid()) @db.Uuid
   createdAt   DateTime        @default(now()) @db.Timestamptz(6)
   createdBy   String          @db.Uuid
-  updatedAt   DateTime?       @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime?       @updatedAt @db.Timestamptz(6)
   updatedBy   String?         @db.Uuid
   name        String          @db.VarChar(70)
   description String?
@@ -114,7 +114,7 @@ model Version {
   id        String          @id @default(uuid()) @db.Uuid
   createdAt DateTime        @default(now()) @db.Timestamptz(6)
   createdBy String          @db.Uuid
-  updatedAt DateTime?       @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime?       @updatedAt @db.Timestamptz(6)
   updatedBy String?         @db.Uuid
   name      String          @db.VarChar(70)
   changelog String?
@@ -152,7 +152,7 @@ model Image {
   instances  Instance[]
   createdAt  DateTime         @default(now()) @db.Timestamptz(6)
   createdBy  String           @db.Uuid
-  updatedAt  DateTime?        @default(now()) @db.Timestamptz(6)
+  updatedAt  DateTime?        @updatedAt @db.Timestamptz(6)
   updatedBy  String?          @db.Uuid
 
   registry Registry @relation(fields: [registryId], references: [id], onDelete: Cascade)
@@ -175,7 +175,7 @@ model Deployment {
   id          String               @id @default(uuid()) @db.Uuid
   createdAt   DateTime             @default(now()) @db.Timestamptz(6)
   createdBy   String               @db.Uuid
-  updatedAt   DateTime?            @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime?            @updatedAt @db.Timestamptz(6)
   updatedBy   String?              @db.Uuid
   note        String?
   prefix      String?
@@ -193,7 +193,7 @@ model Deployment {
 
 model Instance {
   id           String              @id @default(uuid()) @db.Uuid
-  updatedAt    DateTime            @default(now()) @db.Timestamptz(6)
+  updatedAt    DateTime            @updatedAt @db.Timestamptz(6)
   state        ContainerStateEnum?
   deploymentId String              @db.Uuid
   imageId      String              @db.Uuid
@@ -245,7 +245,7 @@ model Notification {
   id        String               @id @default(uuid()) @db.Uuid
   createdAt DateTime             @default(now()) @db.Timestamptz(6)
   createdBy String               @db.Uuid
-  updatedAt DateTime?            @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime?            @updatedAt @db.Timestamptz(6)
   updatedBy String?              @db.Uuid
   name      String               @db.VarChar(70)
   url       String

--- a/web/crux/src/app/deploy/deploy.service.ts
+++ b/web/crux/src/app/deploy/deploy.service.ts
@@ -150,7 +150,6 @@ export default class DeployService {
       data: {
         note: request.note,
         prefix: request.prefix,
-        updatedAt: new Date(),
         updatedBy: request.accessedBy,
       },
       where: {
@@ -178,12 +177,9 @@ export default class DeployService {
       }
     }
 
-    const now = new Date()
-
     const deployment = await this.prisma.deployment.update({
       data: {
         environment: request.environment?.data as JsonArray,
-        updatedAt: now,
         updatedBy: request.accessedBy,
         instances: !reqInstance
           ? undefined
@@ -193,7 +189,6 @@ export default class DeployService {
                   id: reqInstance.id,
                 },
                 data: {
-                  updatedAt: now,
                   config: {
                     upsert: {
                       update: instanceConfigPatchSet,

--- a/web/crux/src/app/image/image.service.ts
+++ b/web/crux/src/app/image/image.service.ts
@@ -119,7 +119,6 @@ export default class ImageService {
         data: {
           order: index,
           updatedBy: request.accessedBy,
-          updatedAt: new Date(),
         },
         where: {
           id: it,
@@ -158,7 +157,6 @@ export default class ImageService {
           update: config,
         },
         updatedBy: request.accessedBy,
-        updatedAt: new Date(),
       },
       where: {
         id: request.id,

--- a/web/crux/src/app/node/node.service.ts
+++ b/web/crux/src/app/node/node.service.ts
@@ -106,7 +106,6 @@ export default class NodeService {
         description: req.description,
         icon: req.icon ?? null,
         updatedBy: req.accessedBy,
-        updatedAt: new Date(),
       },
     })
 
@@ -123,7 +122,6 @@ export default class NodeService {
       data: {
         type: nodeType,
         updatedBy: req.accessedBy,
-        updatedAt: new Date(),
       },
     })
 
@@ -162,7 +160,6 @@ export default class NodeService {
       },
       data: {
         token: null,
-        updatedAt: new Date(),
         updatedBy: request.accessedBy,
       },
     })

--- a/web/crux/src/app/notification/notification.service.ts
+++ b/web/crux/src/app/notification/notification.service.ts
@@ -78,7 +78,6 @@ export default class NotificationService {
         active: !!request.active,
         type: this.mapper.typeToDb(request.type),
         updatedBy: request.accessedBy,
-        updatedAt: new Date(),
         events: {
           deleteMany: {
             id: {

--- a/web/crux/src/app/product/product.service.ts
+++ b/web/crux/src/app/product/product.service.ts
@@ -93,7 +93,6 @@ export default class ProductService {
         name: req.name,
         description: req.description,
         updatedBy: req.accessedBy,
-        updatedAt: new Date(),
         versions:
           product.type === ProductTypeEnum.simple
             ? {

--- a/web/crux/src/app/registry/registry.service.ts
+++ b/web/crux/src/app/registry/registry.service.ts
@@ -65,7 +65,6 @@ export default class RegistryService {
         description: req.description,
         icon: req.icon ?? null,
         updatedBy: req.accessedBy,
-        updatedAt: new Date(),
         ...this.mapper.detailsToDb(req),
       },
     })

--- a/web/crux/src/app/team/team.service.ts
+++ b/web/crux/src/app/team/team.service.ts
@@ -174,7 +174,6 @@ export default class TeamService {
       data: {
         name: request.name,
         updatedBy: request.accessedBy,
-        updatedAt: new Date(),
       },
     })
 
@@ -263,7 +262,6 @@ export default class TeamService {
         team: {
           update: {
             updatedBy: request.accessedBy,
-            updatedAt: new Date(),
           },
         },
       },

--- a/web/crux/src/app/version/version.service.ts
+++ b/web/crux/src/app/version/version.service.ts
@@ -158,7 +158,6 @@ export default class VersionService {
       data: {
         name: req.name,
         changelog: req.changelog,
-        updatedAt: new Date(),
         updatedBy: req.accessedBy,
       },
     })


### PR DESCRIPTION
Replaces `@default(now())` with `@updatedAt` and removes all `updatedAt` in code when updating records.

> Important: This PR introduces one unwanted behavior, where new records created may have the `updatedAt` field not matching `createdAt` if wherever the database is hosted uses a different system time than the client, due to https://github.com/prisma/prisma/issues/12572.

The above unwanted behavior is tracked in #219.

Feedback is welcome!

Closes #208.