### PR TITLE
feat: check open/duplicate port when fire up dyrectorio stack with cli

### DIFF
--- a/cli/runner.go
+++ b/cli/runner.go
@@ -31,9 +31,10 @@ func ProcessCommand(settings *Settings) {
 	containers := DyrectorioStack{
 		Containers: settings.Containers,
 	}
-
 	switch settings.Command {
 	case "up":
+		settings = CheckAndUpdatePorts(settings)
+
 		containers.Crux = GetCrux(settings)
 		containers.CruxMigrate = GetCruxMigrate(settings)
 		containers.CruxUI = GetCruxUI(settings)


### PR DESCRIPTION
Fixes: #237 

Changes:
- Verify that exposed port from `dyrectorio` stack is available on host
- Prompt user for another port for `stack` element
- Find duplicate `external` port after changes

Demo:
- start listening on port `5432`
```bash
nc -l 5432
```
- run `dyrectorio` stack setup
```
go run . up
```

https://user-images.githubusercontent.com/25000090/193915452-f07e8d96-02c0-4a0d-b80c-dae4d8a9bb23.mov

