### PR TITLE
fix(cli): named pipe "deprecation", add socket to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,21 +91,21 @@ This means you get a full-featured dyrector.io platform running locally on your 
 > The CLI is only available from the codebase at the moment. 
 
 1. Clone the repository to your local workdir with `git clone`
-2. Execute `go run ./cli up` in the project root
+2. Execute `go run ./golang/cmd/dyo up` in the project root
 3. Open the `localhost:8000` and use the platform
 
 dyrector.io's command-line interface (CLI) lets you run a complete dyrector.io development environment locally with the following services: UI Service (crux-ui), Backend Service (crux), PostgreSQL databases, Authentication, Migrations, and SMTP mail server.
 
 #### Using the platform with CLI for demonstration or testing
 
-1. Execute `go run ./cli up` in the project root
+1. Execute `go run ./golang/cmd/dyo up` in the project root
 2. After you navigated to `localhost:8000` (this is the default traefik port) you will see a Login screen
 3. Register an account with whatever e-mail address you see fit (doesn't have to be valid one)
 4. Navigate to `localhost:4436` where you will find your mail as all outgoing e-mails will land here
 5. Open your e-mail message and using the link inside you can activate your account
 6. Enjoy!
 
-#### Usint the platform with CLI for development
+#### Using the platform with CLI for development
 
 1. Read the CLI documentation first(see the end of this section)
 2. Decide which part of the project you want to work on, in this case it is crux, crux-ui or both

--- a/golang/pkg/cli/config_file.go
+++ b/golang/pkg/cli/config_file.go
@@ -65,26 +65,28 @@ type SettingsFile struct {
 }
 
 type Options struct {
-	TimeZone               string `yaml:"timezone" env-default:"Europe/Budapest"`
-	CruxAgentGrpcPort      uint   `yaml:"crux-agentgrpc-port" env-default:"5000"`
-	CruxGrpcPort           uint   `yaml:"crux-grpc-port" env-default:"5001"`
-	CruxUIPort             uint   `yaml:"crux-ui-port" env-default:"3000"`
-	CruxSecret             string `yaml:"crux-secret"`
-	CruxPostgresPort       uint   `yaml:"cruxPostgresPort" env-default:"5432"`
-	CruxPostgresDB         string `yaml:"cruxPostgresDB" env-default:"crux"`
-	CruxPostgresUser       string `yaml:"cruxPostgresUser" env-default:"crux"`
-	CruxPostgresPassword   string `yaml:"cruxPostgresPassword"`
-	TraefikWebPort         uint   `yaml:"traefikWebPort" env-default:"8000"`
-	TraefikUIPort          uint   `yaml:"traefikUIPort" env-default:"8080"`
-	KratosAdminPort        uint   `yaml:"kratosAdminPort" env-default:"4434"`
-	KratosPublicPort       uint   `yaml:"kratosPublicPort" env-default:"4433"`
-	KratosPostgresPort     uint   `yaml:"kratosPostgresPort" env-default:"5433"`
-	KratosPostgresDB       string `yaml:"kratosPostgresDB" env-default:"kratos"`
-	KratosPostgresUser     string `yaml:"kratosPostgresUser" env-default:"kratos"`
-	KratosPostgresPassword string `yaml:"kratosPostgresPassword"`
-	KratosSecret           string `yaml:"kratosSecret"`
-	MailSlurperPort        uint   `yaml:"mailSlurperPort" env-default:"4436"`
-	MailSlurperPort2       uint   `yaml:"mailSlurperPort2" env-default:"4437"`
+	TimeZone                       string `yaml:"timezone" env-default:"Europe/Budapest"`
+	CruxAgentGrpcPort              uint   `yaml:"crux-agentgrpc-port" env-default:"5000"`
+	CruxGrpcPort                   uint   `yaml:"crux-grpc-port" env-default:"5001"`
+	CruxUIPort                     uint   `yaml:"crux-ui-port" env-default:"3000"`
+	CruxSecret                     string `yaml:"crux-secret"`
+	CruxPostgresPort               uint   `yaml:"cruxPostgresPort" env-default:"5432"`
+	CruxPostgresDB                 string `yaml:"cruxPostgresDB" env-default:"crux"`
+	CruxPostgresUser               string `yaml:"cruxPostgresUser" env-default:"crux"`
+	CruxPostgresPassword           string `yaml:"cruxPostgresPassword"`
+	TraefikWebPort                 uint   `yaml:"traefikWebPort" env-default:"8000"`
+	TraefikUIPort                  uint   `yaml:"traefikUIPort" env-default:"8080"`
+	TraefikDockerSocket            string `yaml:"traefikDockerSocket" env-default:"/var/run/docker.sock"`
+	TraefikIsDockerSocketNamedPipe bool   `yaml:"traefikIsDockerSocketNamedPipe" env-default:"false"`
+	KratosAdminPort                uint   `yaml:"kratosAdminPort" env-default:"4434"`
+	KratosPublicPort               uint   `yaml:"kratosPublicPort" env-default:"4433"`
+	KratosPostgresPort             uint   `yaml:"kratosPostgresPort" env-default:"5433"`
+	KratosPostgresDB               string `yaml:"kratosPostgresDB" env-default:"kratos"`
+	KratosPostgresUser             string `yaml:"kratosPostgresUser" env-default:"kratos"`
+	KratosPostgresPassword         string `yaml:"kratosPostgresPassword"`
+	KratosSecret                   string `yaml:"kratosSecret"`
+	MailSlurperPort                uint   `yaml:"mailSlurperPort" env-default:"4436"`
+	MailSlurperPort2               uint   `yaml:"mailSlurperPort2" env-default:"4437"`
 }
 
 const DefaultPostgresPort = 5432


### PR DESCRIPTION
This PR adds support to older docker for windows installations, since newer ones use WSL2; and Docker SDK still using the old method so now the Traefik's socket is configurable, and if we stay at the default and we have a DOCKER_HOST env variable in use, we prefer that.