### PR TITLE
fix(agent): remove comment and version strings from pgp keys

### DIFF
--- a/golang/internal/config/secret.go
+++ b/golang/internal/config/secret.go
@@ -56,7 +56,7 @@ func checkGenerateKeys(secretPath string) (string, error) {
 	}
 
 	if !privateKeyObj.IsExpired() {
-		keyStr, keyErr := privateKeyObj.Armor()
+		keyStr, keyErr := privateKeyObj.ArmorWithCustomHeaders("", "")
 
 		return keyStr, keyErr
 	} else {
@@ -77,7 +77,7 @@ func generateKey(secretPath string) (string, error) {
 	if keyErr != nil {
 		return "", keyErr
 	}
-	keyStr, keyErr := ecKey.Armor()
+	keyStr, keyErr := ecKey.ArmorWithCustomHeaders("", "")
 
 	if keyErr != nil {
 		return "", keyErr
@@ -98,7 +98,7 @@ func GetPublicKey(keyStr string) (string, error) {
 		return "", fmt.Errorf("could not get key from armored key: %w", err)
 	}
 
-	publicKey, err := key.GetArmoredPublicKey()
+	publicKey, err := key.GetArmoredPublicKeyWithCustomHeaders("", "")
 	if err != nil {
 		return "", fmt.Errorf("could not get public key from key object: %w", err)
 	}

--- a/golang/internal/config/secret_test.go
+++ b/golang/internal/config/secret_test.go
@@ -14,8 +14,6 @@ import (
 const (
 	missingKeyFile = "missing-file.key"
 	testPrivateKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----
-Version: GopenPGP 2.4.8
-Comment: https://gopenpgp.org
 
 xVgEY0a/axYJKwYBBAHaRw8BAQdAYOtTwtAIPQpkekA0EGFSD8AkBQXSsyX/LjgE
 u9DbDREAAQDrm97I/otLFVS2+Hy1puy7r1TX0D0y5IWIpADhLsHOTxMxzSVkeXJl
@@ -32,8 +30,6 @@ VA6Ob1z0jQk=
 -----END PGP PRIVATE KEY BLOCK-----`
 
 	testPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GopenPGP 2.4.8
-Comment: https://gopenpgp.org
 
 xjMEY0a/axYJKwYBBAHaRw8BAQdAYOtTwtAIPQpkekA0EGFSD8AkBQXSsyX/LjgE
 u9DbDRHNJWR5cmVjdG9yLmlvIGFnZW50IDxoZWxsb0BkeXJlY3Rvci5pbz7CjAQT


### PR DESCRIPTION
default custom headers in PGP blocks are not deterministic because their order is not fixed

so I remove them in this PR