### PR TITLE
feat(agent): rework installscript to respect rootless/podman or other…

### DIFF
--- a/golang/pkg/cli/config_file.go
+++ b/golang/pkg/cli/config_file.go
@@ -85,8 +85,9 @@ type Options struct {
 	KratosPostgresUser             string `yaml:"kratosPostgresUser" env-default:"kratos"`
 	KratosPostgresPassword         string `yaml:"kratosPostgresPassword"`
 	KratosSecret                   string `yaml:"kratosSecret"`
-	MailSlurperPort                uint   `yaml:"mailSlurperPort" env-default:"4436"`
-	MailSlurperPort2               uint   `yaml:"mailSlurperPort2" env-default:"4437"`
+	MailSlurperSMTPPort            uint   `yaml:"mailSlurperSMTPPort" env-default:"1025"`
+	MailSlurperWebPort             uint   `yaml:"mailSlurperWebPort" env-default:"4436"`
+	MailSlurperWebPort2            uint   `yaml:"mailSlurperWebPort2" env-default:"4437"`
 }
 
 const DefaultPostgresPort = 5432
@@ -106,17 +107,18 @@ const (
 )
 
 const (
-	CruxAgentGrpcPort  = "CruxAgentGrpcPort"
-	CruxGrpcPort       = "CruxGrpcPort"
-	CruxUIPort         = "CruxUIPort"
-	KratosAdminPort    = "KratosAdminPort"
-	KratosPublicPort   = "KratosPublicPort"
-	KratosPostgresPort = "KratosPostgresPort"
-	MailSlurperPort    = "MailSlurperPort"
-	MailSlurperPort2   = "MailSlurperPort2"
-	CruxPostgresPort   = "CruxPostgresPort"
-	TraefikWebPort     = "TraeficWebPort"
-	TraefikUIPort      = "TraefikUIPort"
+	CruxAgentGrpcPort   = "CruxAgentGrpcPort"
+	CruxGrpcPort        = "CruxGrpcPort"
+	CruxUIPort          = "CruxUIPort"
+	KratosAdminPort     = "KratosAdminPort"
+	KratosPublicPort    = "KratosPublicPort"
+	KratosPostgresPort  = "KratosPostgresPort"
+	MailSlurperSMTPPort = "MailSlurperSMTPPort"
+	MailSlurperWebPort  = "MailSlurperWebPort"
+	MailSlurperWebPort2 = "MailSlurperWebPort2"
+	CruxPostgresPort    = "CruxPostgresPort"
+	TraefikWebPort      = "TraeficWebPort"
+	TraefikUIPort       = "TraefikUIPort"
 )
 
 const (
@@ -427,12 +429,15 @@ func CheckAndUpdatePorts(settings *Settings) *Settings {
 	portMap[KratosPostgresPort] = getAvailablePort(portMap, settings.SettingsFile.Options.KratosPostgresPort,
 		KratosPostgresPort, &settings.SettingsWrite)
 	settings.SettingsFile.Options.KratosPostgresPort = portMap[KratosPostgresPort]
-	portMap[MailSlurperPort] = getAvailablePort(portMap, settings.SettingsFile.Options.MailSlurperPort,
-		MailSlurperPort, &settings.SettingsWrite)
-	settings.SettingsFile.Options.MailSlurperPort = portMap[MailSlurperPort]
-	portMap[MailSlurperPort2] = getAvailablePort(portMap, settings.SettingsFile.Options.MailSlurperPort2,
-		MailSlurperPort2, &settings.SettingsWrite)
-	settings.SettingsFile.Options.MailSlurperPort2 = portMap[MailSlurperPort2]
+	portMap[MailSlurperSMTPPort] = getAvailablePort(portMap, settings.SettingsFile.Options.MailSlurperSMTPPort,
+		MailSlurperSMTPPort, &settings.SettingsWrite)
+	settings.SettingsFile.Options.MailSlurperSMTPPort = portMap[MailSlurperSMTPPort]
+	portMap[MailSlurperWebPort] = getAvailablePort(portMap, settings.SettingsFile.Options.MailSlurperWebPort,
+		MailSlurperWebPort, &settings.SettingsWrite)
+	settings.SettingsFile.Options.MailSlurperWebPort = portMap[MailSlurperWebPort]
+	portMap[MailSlurperWebPort2] = getAvailablePort(portMap, settings.SettingsFile.Options.MailSlurperWebPort2,
+		MailSlurperWebPort2, &settings.SettingsWrite)
+	settings.SettingsFile.Options.MailSlurperWebPort2 = portMap[MailSlurperWebPort2]
 	portMap[TraefikWebPort] = getAvailablePort(portMap, settings.SettingsFile.Options.TraefikWebPort,
 		TraefikWebPort, &settings.SettingsWrite)
 	settings.SettingsFile.Options.TraefikWebPort = portMap[TraefikWebPort]

--- a/golang/pkg/cli/container_defaults.go
+++ b/golang/pkg/cli/container_defaults.go
@@ -19,15 +19,16 @@ const (
 )
 
 const (
-	defaultCruxAgentGrpcPort = 5000
-	defaultCruxGrpcPort      = 5001
-	defaultCruxUIPort        = 3000
-	defaultTraefikWebPort    = 8000
-	defaultTraefikUIPort     = 8080
-	defaultKratosPublicPort  = 4433
-	defaultKratosAdminPort   = 4434
-	defaultMailSlurperPort   = 4436
-	defaultMailSlurperPort2  = 4437
+	defaultCruxAgentGrpcPort   = 5000
+	defaultCruxGrpcPort        = 5001
+	defaultCruxUIPort          = 3000
+	defaultTraefikWebPort      = 8000
+	defaultTraefikUIPort       = 8080
+	defaultKratosPublicPort    = 4433
+	defaultKratosAdminPort     = 4434
+	defaultMailSlurperSMTPPort = 1025
+	defaultMailSlurperWebPort  = 4436
+	defaultMailSlurperWebPort2 = 4437
 )
 
 // Crux services: db migrations and crux api service
@@ -312,12 +313,16 @@ func GetMailSlurper(settings *Settings) *containerbuilder.DockerContainerBuilder
 		WithForcePullImage().
 		WithPortBindings([]containerbuilder.PortBinding{
 			{
-				ExposedPort: defaultMailSlurperPort,
-				PortBinding: uint16(settings.SettingsFile.MailSlurperPort),
+				ExposedPort: defaultMailSlurperSMTPPort,
+				PortBinding: uint16(settings.SettingsFile.MailSlurperSMTPPort),
 			},
 			{
-				ExposedPort: defaultMailSlurperPort2,
-				PortBinding: uint16(settings.SettingsFile.MailSlurperPort2),
+				ExposedPort: defaultMailSlurperWebPort,
+				PortBinding: uint16(settings.SettingsFile.MailSlurperWebPort),
+			},
+			{
+				ExposedPort: defaultMailSlurperWebPort2,
+				PortBinding: uint16(settings.SettingsFile.MailSlurperWebPort2),
 			},
 		}).
 		WithNetworks([]string{settings.SettingsFile.Network}).

--- a/web/crux/install-docker.sh.hbr
+++ b/web/crux/install-docker.sh.hbr
@@ -1,72 +1,132 @@
 #!/bin/sh
 
-set -e
+set -euo pipefail
 
-if [ $(id -u) -ne 0 ]; then
-  echo "Installation process needs root privileges" 1>&2
-  sudo -s
-fi
+set_environment() {
+  MSYS_NO_PATHCONV=1
 
-# Setup the default root folder for volumes
-if [ $(uname -s) = 'Darwin' ]; then
-  echo "Detected: Mac OS X"
-  ROOT_FOLDER={{#if rootPath}}'{{{rootPath}}}'{{else}}$HOME'/Library/Dyrectorio/srv/dagent'{{/if}}
-elif [ $(uname -s) = 'Linux' ]; then
-  echo "Detected: Linux"
-  ROOT_FOLDER='{{#if rootPath}}{{{rootPath}}}{{else}}/srv/dagent{{/if}}'
-else
-  echo "Not supported OS!"
-fi
+  ROOTLESS="${ROOTLESS:-false}"
+  if [ $ROOTLESS != "true" ]; then
+    if [ $(id -u) -ne 0 ]; then
+      echo "Installation process needs root privileges" 1>&2
+      sudo -s
+    fi
+  fi
 
-if [ -z "$(which docker)" ]; then
-  echo "Docker is required, make sure it is installed and available in PATH!"
-  exit 1
-fi
+# Set folder for persisting data
+  PERSISTENCE_FOLDER_FROM_CRUX="{{#if rootPath}}{{{rootPath}}}{{/if}}"
+  if [ -z ${PERSISTENCE_FOLDER:-} ]; then
+    if [ -z ${PERSISTENCE_FOLDER_FROM_CRUX:-} ]; then
+      case $(uname -s) in
+      'Darwin')
+        echo "Detected: Mac OS X"
+        PERSISTENCE_FOLDER=$HOME/Library/Dyrectorio/srv/dagent
+        ;;
+      'Linux')
+        echo "Detected: Linux"
+        PERSISTENCE_FOLDER=/srv/dagent
+        ;;
+      *)
+        echo "Not supported OS and PERSISTENCE_FOLDER is not set!"
+        exit 1
+        ;;
+      esac
+    else
+      PERSISTENCE_FOLDER=$PERSISTENCE_FOLDER_FROM_CRUX
+    fi
+  fi
 
-echo "Installing dyrector.io agent (dagent)..."
+  mkdir -p $PERSISTENCE_FOLDER
 
-if [ $(docker ps --no-trunc --filter name=^/dagent$ | tail -n +2 | wc -l) -eq 1 ]; then
-  echo "DAgent is is running already, terminating"
-  docker stop dagent
-fi
+  if [ -z ${CRI_EXECUTABLE:-} ]; then
+    if [ -z "$(which docker)" ]; then
+      if [ -z "$(which podman)" ]; then
+        echo "Docker is required, make sure it is installed and available in PATH!"
+        exit 1
+      else
+        CRI_EXECUTABLE="podman"
+      fi
+    fi
+    CRI_EXECUTABLE="docker"
+  fi
 
-if [ $(docker ps -a --no-trunc --filter name=^/dagent$ | tail -n +2 | wc -l) -eq 1 ]; then
-  docker rm dagent
-else
-  echo "DAgent not running, installing..."
-fi
+  if [ -z ${HOST_DOCKER_SOCK_PATH:-} ]; then
+    if [ -z ${DOCKER_HOST:-} ]; then
+      HOST_DOCKER_SOCK_PATH="/var/run/docker.sock"
+    else 
+      if [ ${DOCKER_HOST:0:7} = "unix://" ]; then
+        HOST_DOCKER_SOCK_PATH=${DOCKER_HOST:7}
+      else
+        echo "Invalid DOCKER_HOST variable please set HOST_DOCKER_SOCK_PATH if your socket is in a custom location otherwise unset DOCKER_HOST!"
+        exit 1
+      fi
+    fi
+  fi
 
-mkdir -p $ROOT_FOLDER
-docker pull ghcr.io/dyrector-io/dyrectorio/agent/dagent:latest
+  if [ -z ${HOSTNAME:-} ]; then
+    if [ -z ${HOST:-} ]; then
+      HOSTNAME='{{name}}'
+    else
+      HOSTNAME=$HOST
+    fi
+  fi
+}
 
-MSYS_NO_PATHCONV=1
+dagent_clean() {
+  echo "Installing dyrector.io agent (dagent)..."
 
-docker run \
-  --restart unless-stopped \
-  -e GRPC_TOKEN='{{token}}' \
-  -e HOSTNAME="$HOSTNAME || $HOST || '{{name}}'" \
-  {{#if traefik}}
+  if [ -n $($CRI_EXECUTABLE container list --filter name=^dagent$ --filter=status=running --filter=status=restarting --filter=status=paused --format '{{{{raw-helper}}}}{{ .Names }}{{{{/raw-helper}}}}' 2>/dev/null) ]; then
+    timeout 5 $CRI_EXECUTABLE stop dagent
+    if [ $? -ne 0 ]; then
+      $CRI_EXECUTABLE kill dagent
+    fi
+  fi
+
+  if [ -n $($CRI_EXECUTABLE container list --filter name=^dagent$ --filter=status=exited --filter=status=created --filter=status=dead --format '{{{{raw-helper}}}}{{ .Names }}{{{{/raw-helper}}}}' 2>/dev/null) ]; then
+    timeout 5 $CRI_EXECUTABLE rm dagent
+    if [ $? -ne 0 ]; then
+      $CRI_EXECUTABLE rm -f dagent
+    fi
+  fi
+}
+
+dagent_install() {
+  $CRI_EXECUTABLE pull ghcr.io/dyrector-io/dyrectorio/agent/dagent:latest
+
+  $CRI_EXECUTABLE run \
+    --restart unless-stopped \
+    {{#if network}}
+    --network {{networkName}} \
+    {{/if}}
+    -e GRPC_TOKEN='{{token}}' \
+    -e HOSTNAME=$HOSTNAME \
+    {{#if traefik}}
     -e TRAEFIK= 'true' \
-  {{/if}}
-  -e DATA_MOUNT_PATH=$ROOT_FOLDER \
-  -e UPDATE_METHOD='off' \
-  -e UPDATE_POLL_INTERVAL='600s' \
-  {{#if insecure}}
-  -e GRPC_INSECURE='true' \
-  {{/if}}
-  -e DAGENT_IMAGE='ghcr.io/dyrector-io/dyrectorio/agent/dagent' \
-  -e DAGENT_TAG='stable' \
-  -e DAGENT_NAME='{{name}}' \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  {{#if network}}
-  --network {{networkName}} \
-  {{/if}}
-  --name 'dagent' \
-  {{! -e UPDATE_REGISTRY_USER='' \ }}
-  {{! -e UPDATE_REGISTRY_PASSWORD='' \ }}
-  {{! -e UPDATER_CONTAINER_NAME ='' \ }}
-  {{! -e UPDATE_HOST_TIMEZONE='' \ }}
-  {{! -e HOST_DOCKER_SOCK_PATH='' \ }}
-  {{! -e WEBHOOK_TOKEN='' \ }}
-  {{! -e DISCORD_WEBHOOK_URL='' \ }}
-  -v $ROOT_FOLDER/:/srv/dagent -d ghcr.io/dyrector-io/dyrectorio/agent/dagent:latest
+    {{/if}}
+    -e DATA_MOUNT_PATH=$PERSISTENCE_FOLDER \
+    -e UPDATE_METHOD='off' \
+    -e UPDATE_POLL_INTERVAL='600s' \
+    {{#if insecure}}
+    -e GRPC_INSECURE='true' \
+    {{/if}}
+    -e DAGENT_IMAGE='ghcr.io/dyrector-io/dyrectorio/agent/dagent' \
+    -e DAGENT_TAG='stable' \
+    -e DAGENT_NAME='{{name}}' \
+    -e HOST_DOCKER_SOCK_PATH=$HOST_DOCKER_SOCK_PATH \
+    --name 'dagent' \
+    {{! -e UPDATE_REGISTRY_USER='' \ }}
+    {{! -e UPDATE_REGISTRY_PASSWORD='' \ }}
+    {{! -e UPDATER_CONTAINER_NAME ='' \ }}
+    {{! -e UPDATE_HOST_TIMEZONE='' \ }}
+    {{! -e WEBHOOK_TOKEN='' \ }}
+    {{! -e DISCORD_WEBHOOK_URL='' \ }}
+    -v $PERSISTENCE_FOLDER/:/srv/dagent \
+    -v $HOST_DOCKER_SOCK_PATH:/var/run/docker.sock \
+    -d ghcr.io/dyrector-io/dyrectorio/agent/dagent:latest
+}
+
+set_environment
+
+dagent_clean
+
+dagent_install


### PR DESCRIPTION
…wise different hosts; expose mailslurper smtpport

when I started I came top a realization: i need to expose SMTP as well (nobody told me which means you did not used it? :smiling_imp: )

main scope is reworking dagent install script so it will work in wider array of environments (podman, doesn't need root, etc) but these need set environment variables which could be added to the UI later