### PR TITLE
chore: goair for new watch tool and makefile modified (#155)

### DIFF
--- a/golang/.gitignore
+++ b/golang/.gitignore
@@ -1,4 +1,5 @@
 build/out
+tmp/
 .env
 *.env
 __debug_bin

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -17,6 +17,7 @@ LDFLAGS := -ldflags "-X '${PACKAGE}/pkg/version.Version=${VCS_VERSION}'\
 # default tag is latest for building
 image_version ?= latest
 
+GOAIR=v1.40.4
 GOSEC=v2.12.0
 GOLANGCI=v1.46.2
 GOSWAG=v1.8.3
@@ -47,15 +48,11 @@ down: ##
 
 .PHONY: go-crane
 go-crane: ##
-	cd cmd/crane && \
-	go run . ; \
-	cd -
+	air --build.cmd "cd cmd/crane; go run ."
 
 .PHONY: go-dagent
 go-dagent: ##
-	cd cmd/dagent && \
-	go run . ; \
-	cd -
+	air --build.cmd "cd cmd/dagent; go run ."
 
 
 .PHONY: compile-cli
@@ -78,6 +75,7 @@ compile-dagent: ##
 
 .PHONY: install-go-tools
 install-go-tools: ##
+	go install github.com/cosmtrek/air@${GOAIR} && \
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI} && \
 	go install github.com/swaggo/swag/cmd/swag@${GOSWAG} && \
 	go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC}


### PR DESCRIPTION
- Issue [#155](https://github.com/dyrector-io/dyrectorio/issues/115)

Applied to two build targets: `go-crane` & `go-dagent`.
Not applied to `debug-grpc`. (reason: uncertain target purpose)

Possible Future Actions:
1. Add the graceful shutdown to `golang/internal/grpc/grpc.go:grpcLoop()` via [signal catching](https://github.com/cosmtrek/air/blob/bb7fe2887750390eee13daa25348723a5fb20308/main.go#L61-L62) method.
2. Watch with [send_interrupt=true](https://github.com/cosmtrek/air/blob/a2b8871f2ae8de60526b9f8ccc01b69fad9d138a/air_example.toml#L37-L38) on goair.
