### PR TITLE
feat: add self managed gitlab template

### DIFF
--- a/web/crux-ui/e2e/template.spec.ts
+++ b/web/crux-ui/e2e/template.spec.ts
@@ -54,3 +54,11 @@ test('creating a simple product from a template should work (Strapi)', async ({ 
 test('creating a complex product from a template should work (Strapi)', async ({ page }) => {
   await testComplexTemplate(page, 'Strapi', 'Strapi-complex', 2)
 })
+
+test('creating a simple product from a template should work (Gitlab)', async ({ page }) => {
+  await testSimpleTemplate(page, 'Self-managed GitLab', 'Gitlab-simple', 1)
+})
+
+test('creating a complex product from a template should work (Gitlab)', async ({ page }) => {
+  await testComplexTemplate(page, 'Self-managed GitLab', 'Gitlab-complex', 1)
+})

--- a/web/crux/templates/self-hosted-gitlab.json
+++ b/web/crux/templates/self-hosted-gitlab.json
@@ -1,0 +1,53 @@
+{
+  "name": "Self-managed GitLab",
+  "description": "This template contains Self-managed GitLab, deploy and maintain your own GitLab instance.",
+  "registries": [
+    {
+      "name": "Docker Hub Gitlab",
+      "type": "hub",
+      "hub": {
+        "imageNamePrefix": "gitlab"
+      }
+    }
+  ],
+  "images": [
+    {
+      "name": "Gitlab self-managed",
+      "registryName": "Docker Hub Gitlab",
+      "image": "gitlab-ce",
+      "tag": "latest",
+      "config": {
+        "name": "gitlab-self-managed",
+        "ports": [
+          {
+            "external": 21443,
+            "internal": 443
+          },
+          {
+            "external": 21022,
+            "internal": 22
+          },
+          {
+            "external": 21080,
+            "internal": 80
+          }
+        ],
+        "volumes": [
+          {
+            "name": "gitlab",
+            "path": "/etc/gitlab"
+          },
+          {
+            "name": "gitlab-log",
+            "path": "/var/log/gitlab"
+          },
+          {
+            "name": "gitlab-opt",
+            "path": "/var/opt/gitlab"
+          }
+        ],
+        "restartPolicy": "always"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
With the default template ports, you can open your GitLab instance on the '21080' port.