### PR TITLE
fix(agent): correct crane path manifests with distroless image

### DIFF
--- a/golang/manifest/kubernetes/deployment.yaml
+++ b/golang/manifest/kubernetes/deployment.yaml
@@ -19,7 +19,8 @@ spec:
         - name: crane-init
           image: ghcr.io/dyrector-io/dyrectorio/agent/crane:latest
           command:
-            - crane
+            - /agent
+          args:
             - init
           imagePullPolicy: Always
           resources:
@@ -38,6 +39,7 @@ spec:
           resources:
             requests:
               memory: 128Mi
+              cpu: 84m
             limits:
               cpu: 1
               memory: 256Mi


### PR DESCRIPTION
New distroless image needs different start params in manifest, added.