### PR TITLE
fix(crane): use original `containerPreName` as a name for namespace

### DIFF
--- a/golang/pkg/crane/k8s/deploy_facade.go
+++ b/golang/pkg/crane/k8s/deploy_facade.go
@@ -80,7 +80,7 @@ func (d *DeployFacade) CheckPreConditions() error {
 		return fmt.Errorf("instance config name must be provided with environments")
 	}
 
-	err = d.namespace.DeployNamespace(d.params.InstanceConfig.Name)
+	err = d.namespace.DeployNamespace(d.params.InstanceConfig.ContainerPreName)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("pre-deployment failure: %w", err)
 	}


### PR DESCRIPTION
Refactors might have confused me, but this is how this supposed to work.