### PR TITLE
fix(web): hotfix for renaming the node bug

### DIFF
--- a/web/crux-ui/src/components/nodes/edit-node-card.tsx
+++ b/web/crux-ui/src/components/nodes/edit-node-card.tsx
@@ -211,6 +211,7 @@ const EditNodeCard = (props: EditNodeCardProps) => {
               onChange={formik.handleChange}
               value={formik.values.name}
               required
+              disabled
               grow
               message={formik.errors.name}
             />

--- a/web/crux-ui/src/pages/nodes/[nodeId].tsx
+++ b/web/crux-ui/src/pages/nodes/[nodeId].tsx
@@ -93,9 +93,7 @@ const NodeDetails = (props: NodeDetailsProps) => {
 
             <NodeConnectionCard className="w-1/3 px-6 py-4" node={node} />
           </div>
-
           <Filters setTextFilter={it => state.filters.setFilter({ text: it })} />
-
           <NodeContainersList state={state} actions={actions} />
         </>
       )}

--- a/web/crux/src/app/node/node.service.ts
+++ b/web/crux/src/app/node/node.service.ts
@@ -103,7 +103,8 @@ export default class NodeService {
         id: req.id,
       },
       data: {
-        name: req.name,
+        // TODO(polaroi8d): renaming the node destroy the connection between the agent and the platform
+        // name: req.name,
         description: req.description,
         icon: req.icon ?? null,
         updatedBy: req.accessedBy,


### PR DESCRIPTION
At present renaming, the node destroys the connection between the platform and the agent, so the fastest workaround is to disable renaming the node after the creation. 