### PR TITLE
fix(crane): remove old crane volume manifest

### DIFF
--- a/web/crux/assets/install-script/install-k8s.sh.hbr
+++ b/web/crux/assets/install-script/install-k8s.sh.hbr
@@ -24,10 +24,8 @@ EOF
 
 {{#if localManifests }}
 kubectl apply -f ./golang/manifest/kubernetes/rolebinding.yaml
-kubectl apply -f ./golang/manifest/kubernetes/volume.yaml
 kubectl apply -f ./golang/manifest/kubernetes/deployment.yaml
 {{else}}
 kubectl apply -f https://raw.githubusercontent.com/dyrector-io/dyrectorio/main/golang/manifest/kubernetes/rolebinding.yaml
-kubectl apply -f https://raw.githubusercontent.com/dyrector-io/dyrectorio/main/golang/manifest/kubernetes/volume.yaml
 kubectl apply -f https://raw.githubusercontent.com/dyrector-io/dyrectorio/main/golang/manifest/kubernetes/deployment.yaml
 {{/if }}


### PR DESCRIPTION
Old, currently missing manifest file blocks the Kubernetes agent install flow, removed. 