### PR TITLE
fix: dyrectorio compose traefik has missing labels

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,6 @@ services:
     restart: unless-stopped
 
   crux:
-    container_name: dyrectorio_crux
     image: ghcr.io/dyrector-io/dyrectorio/web/crux:${DYO_VERSION:-stable}
     command:
       - serve
@@ -53,16 +52,21 @@ services:
       - traefik.enable=true
       - traefik.http.routers.crux.rule=(Host(`${DOMAIN}`) && Headers(`content-type`, `application/grpc`))
       - traefik.http.routers.crux.entrypoints=websecure
+      - traefik.http.routers.crux.service=crux
       - traefik.http.services.crux.loadbalancer.server.port=5000
       - traefik.http.services.crux.loadbalancer.server.scheme=h2c
       - traefik.http.routers.crux.tls=true
       - traefik.http.routers.crux.tls.domains[0].main=${DOMAIN}
       - traefik.http.routers.crux.tls.certresolver=letsencrypt
       - traefik.http.routers.crux-http.rule=Host(`${DOMAIN}`) && PathPrefix(`/api/new`)
-      - traefik.http.routers.crux-http.entrypoints=web
+      - traefik.http.routers.crux-http.entrypoints=websecure
+      - traefik.http.routers.crux-http.service=crux-http
       - traefik.http.services.crux-http.loadbalancer.server.port=1848
-      - traefik.http.middlewares.crux-strip.stripprefix.prefixes=/api/new
       - traefik.http.routers.crux-http.middlewares=crux-strip
+      - traefik.http.routers.crux-http.tls=true
+      - traefik.http.routers.crux-http.tls.domains[0].main=${DOMAIN}
+      - traefik.http.routers.crux-http.tls.certresolver=letsencrypt
+      - traefik.http.middlewares.crux-strip.stripprefix.prefixes=/api/new
     # ports:
     #   - 1848:1848 # http API
 
@@ -167,7 +171,6 @@ services:
     restart: "no"
 
   kratos-postgres:
-    container_name: dyrectorio_kratos_postgres
     image: docker.io/library/postgres:13-alpine
     environment:
       - POSTGRES_PASSWORD=${KRATOS_POSTGRES_PASSWORD}


### PR DESCRIPTION
Dyrectorio stack's compose file has a traefik, and there was a few new labels introduced, and since there was a new service as well, traefik couldn't deduct which router connects to which service.