### PR TITLE
docs(web): improve descriptions of the api

### DIFF
--- a/web/crux-ui/src/routes.ts
+++ b/web/crux-ui/src/routes.ts
@@ -216,8 +216,6 @@ export const deploymentUrl = (deploymentId: string) => `${ROUTE_DEPLOYMENTS}/${d
 
 export const deploymentApiUrl = (deploymentId: string) => `${API_DEPLOYMENTS}/${deploymentId}`
 
-export const deploymentEventsApiUrl = (deploymentId: string) => `${deploymentApiUrl(deploymentId)}/events`
-
 export const deploymentWsUrl = (deploymentId: string) => `${deploymentUrl(deploymentId)}`
 
 export const deploymentDeployUrl = (deploymentId: string) => `${deploymentUrl(deploymentId)}/deploy`

--- a/web/crux/src/app/audit/audit.http.controller.ts
+++ b/web/crux/src/app/audit/audit.http.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, HttpCode, Query } from '@nestjs/common'
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Identity } from '@ory/kratos-client'
+import { AuditLogLevel } from 'src/decorators/audit-logger.decorator'
 import { IdentityFromRequest } from '../token/jwt-auth.guard'
 import { AuditLogListDto, AuditLogQueryDto } from './audit.dto'
 import AuditService from './audit.service'
@@ -17,7 +18,8 @@ export default class AuditController {
       'Request must include `skip`, `take`, and dates of `from` and `to`. Response should include an array of `items`: `createdAt` date, `userId`, `email`, `serviceCall`, and `data`.',
     summary: 'Fetch audit log.',
   })
-  @ApiOkResponse({ type: AuditLogListDto, description: 'Audit log details listed.' })
+  @ApiOkResponse({ type: AuditLogListDto, description: 'Paginated list of the Audit log.' })
+  @AuditLogLevel('all')
   async getAuditLog(
     @Query() query: AuditLogQueryDto,
     @IdentityFromRequest() identity: Identity,

--- a/web/crux/src/app/deploy/deploy.http.controller.ts
+++ b/web/crux/src/app/deploy/deploy.http.controller.ts
@@ -13,10 +13,10 @@ import {
 } from '@nestjs/common'
 import {
   ApiBody,
-  ApiOperation,
   ApiCreatedResponse,
   ApiNoContentResponse,
   ApiOkResponse,
+  ApiOperation,
   ApiTags,
 } from '@nestjs/swagger'
 import { Identity } from '@ory/kratos-client'
@@ -28,7 +28,6 @@ import {
   CreateDeploymentDto,
   DeploymentDetailsDto,
   DeploymentDto,
-  DeploymentEventDto,
   DeploymentLogListDto,
   InstanceDto,
   InstanceSecretsDto,

--- a/web/crux/src/app/deploy/deploy.http.controller.ts
+++ b/web/crux/src/app/deploy/deploy.http.controller.ts
@@ -63,13 +63,13 @@ export default class DeployHttpController {
   @Get()
   @ApiOperation({
     description:
-      'Get details of deployments. Deployment details should include `id`, `prefix`, `status`, `note`, `audit` log details, product `name`, `id`, `type`, version `name`, `type`, `id`, and node `name`, `id`, `type`.',
-    summary: 'Fetch data of deployments.',
+      'Get the list of deployments. A deployment should include `id`, `prefix`, `status`, `note`, `audit` log details, product `name`, `id`, `type`, version `name`, `type`, `id`, and node `name`, `id`, `type`.',
+    summary: 'Fetch the list of deployments.',
   })
   @ApiOkResponse({
     type: DeploymentDto,
     isArray: true,
-    description: 'Details of deployments listed.',
+    description: 'List of deployments.',
   })
   async getDeployments(@IdentityFromRequest() identity: Identity): Promise<DeploymentDto[]> {
     return await this.service.getDeployments(identity)
@@ -80,39 +80,22 @@ export default class DeployHttpController {
   @ApiOperation({
     description:
       'Get details of a certain deployment. Request must include `deploymentId`. Deployment details should include `id`, `prefix`, `environment`, `status`, `note`, `audit` log details, product `name`, `id`, `type`, version `name`, `type`, `id`, and node `name`, `id`, `type`.',
-    summary: 'Retrieve data of a deployment.',
+    summary: 'Retrieve details of a deployment.',
   })
-  @ApiOkResponse({ type: DeploymentDetailsDto, description: 'Data of a deployment is listed.' })
+  @ApiOkResponse({ type: DeploymentDetailsDto, description: 'Details of a deployment.' })
   @UuidParams(PARAM_DEPLOYMENT_ID)
   async getDeploymentDetails(@DeploymentId() deploymentId: string): Promise<DeploymentDetailsDto> {
     return await this.service.getDeploymentDetails(deploymentId)
-  }
-
-  @Get(`${ROUTE_DEPLOYMENT_ID}/events`)
-  @HttpCode(200)
-  @ApiOperation({
-    description:
-      'Request must include `deploymentId`. Response should include `type`, `deploymentStatus`, `createdAt`, `log`, and `containerState` which consists of `state` and `instanceId`.',
-    summary: 'Fetch event log of a deployment.',
-  })
-  @ApiOkResponse({
-    type: DeploymentEventDto,
-    isArray: true,
-    description: 'Event log listed.',
-  })
-  @UuidParams(PARAM_DEPLOYMENT_ID)
-  async getDeploymentEvents(@DeploymentId() deploymentId: string): Promise<DeploymentEventDto[]> {
-    return await this.service.getDeploymentEvents(deploymentId)
   }
 
   @Get(`${ROUTE_DEPLOYMENT_ID}/${ROUTE_INSTANCES}/${ROUTE_INSTANCE_ID}`)
   @HttpCode(200)
   @ApiOperation({
     description:
-      'Request must include `deploymentId` and `instanceId`, which refers to the ID of a deployed container. Response should include `state`, `id`, `updatedAt`, and `image` details including `id`, `name`, `tag`, `order` and `config` variables.',
-    summary: 'Get details of a deployed container.',
+      'Request must include `deploymentId` and `instanceId`, which refer to the ID of a deployment and the instance. Instances are the manifestation of an image in the deployment. Response should include `state`, `id`, `updatedAt`, and `image` details including `id`, `name`, `tag`, `order` and `config` variables.',
+    summary: 'Get details of a soon-to-be container.',
   })
-  @ApiOkResponse({ type: InstanceDto, description: 'Details of deployed container listed.' })
+  @ApiOkResponse({ type: InstanceDto, description: 'Details of an instance.' })
   @UuidParams(PARAM_DEPLOYMENT_ID, PARAM_INSTANCE_ID)
   async getInstance(@DeploymentId() _deploymentId: string, @InstanceId() instanceId: string): Promise<InstanceDto> {
     return await this.service.getInstance(instanceId)
@@ -122,10 +105,10 @@ export default class DeployHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      'Request must include `deploymentId` and `instanceId`, which refers to the ID of a deployed container. Response should include container `prefix` and `name`, and `publicKey`, `keys`.',
-    summary: 'Fetch secrets of a deployed container.',
+      'Request must include `deploymentId` and `instanceId`, which refers to the ID of a deployment and the instance. Response should include container `prefix` and `name`, and `publicKey`, `keys`.',
+    summary: 'Fetch secrets of a soon-to-be container.',
   })
-  @ApiOkResponse({ type: InstanceSecretsDto, description: 'Secrets of a deployed container listed.' })
+  @ApiOkResponse({ type: InstanceSecretsDto, description: 'Secrets of an instance listed.' })
   @UuidParams(PARAM_DEPLOYMENT_ID, PARAM_INSTANCE_ID)
   async getDeploymentSecrets(
     @DeploymentId() _deploymentId: string,
@@ -138,7 +121,7 @@ export default class DeployHttpController {
   @HttpCode(201)
   @ApiOperation({
     description:
-      'Request must include `versionId`, `nodeId`, and `prefix`, which refers to the ID of a deployed container. Response should include deployment `id`, `prefix`, `status`, `note`, and `audit` log details, as well as product `type`, `id`, `name`, version `type`, `id`, `name`, and node `type`, `id`, `name`.',
+      'Request must include `versionId`, `nodeId`, and `prefix`, which refers to the ID of a version, a node and the prefix of the deployment. Response should include deployment `id`, `prefix`, `status`, `note`, and `audit` log details, as well as product `type`, `id`, `name`, version `type`, `id`, `name`, and node `type`, `id`, `name`.',
     summary: 'Create new deployment.',
   })
   @CreatedWithLocation()
@@ -179,7 +162,7 @@ export default class DeployHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      'Request must include `deploymentId` and `instanceId`. Response should include `config` variables in an array.',
+      'Request must include `deploymentId` and `instanceId` and portion of the instance configuration as `config`. Response should include `config` variables in an array.',
     summary: 'Update instance configuration.',
   })
   @UseInterceptors(DeployPatchValidationInterceptor)
@@ -211,7 +194,7 @@ export default class DeployHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `deploymentId`.',
-    summary: 'Start deployment.',
+    summary: 'Start the deployment process.',
   })
   @UseInterceptors(DeployStartValidationInterceptor)
   @ApiNoContentResponse({ description: 'Deployment initiated.' })
@@ -227,12 +210,12 @@ export default class DeployHttpController {
   @HttpCode(201)
   @ApiOperation({
     description:
-      'Request must include `deploymentId` and `force`, which is a boolean variable. Response should include deployment data: `id`, `prefix`, `status`, `note`, and miscellaneous details of `audit` log, `product`, `version`, and `node`.',
+      'Request must include `deploymentId` and `force`, which is when true will overwrite the existing preparing deployment. Response should include deployment data: `id`, `prefix`, `status`, `note`, and miscellaneous details of `audit` log, `product`, `version`, and `node`.',
     summary: 'Copy deployment.',
   })
   @CreatedWithLocation()
-  @UseInterceptors(DeployCopyValidationInterceptor)
   @ApiCreatedResponse({ type: DeploymentDto, description: 'Deployment copied.' })
+  @UseInterceptors(DeployCopyValidationInterceptor)
   @UuidParams(PARAM_DEPLOYMENT_ID)
   async copyDeployment(
     @Query('force') _: boolean,
@@ -247,7 +230,13 @@ export default class DeployHttpController {
   }
 
   @Get(`${ROUTE_DEPLOYMENT_ID}/log`)
-  @ApiOkResponse({ type: DeploymentLogListDto })
+  @HttpCode(200)
+  @ApiOperation({
+    description:
+      'Request must include `deploymentId`. Response should include an `items` array with objects of `type`, `deploymentStatus`, `createdAt`, `log`, and `containerState` which consists of `state` and `instanceId`.',
+    summary: 'Fetch event log of a deployment.',
+  })
+  @ApiOkResponse({ type: DeploymentLogListDto, description: 'Deployment event log.' })
   @UuidParams(PARAM_DEPLOYMENT_ID)
   async deploymentLog(
     @DeploymentId() deploymentId: string,

--- a/web/crux/src/app/health/health.http.controller.ts
+++ b/web/crux/src/app/health/health.http.controller.ts
@@ -17,7 +17,7 @@ export default class HealthHttpController {
   })
   @ApiOkResponse({
     type: HealthDto,
-    description: 'Service status listed.',
+    description: 'Service status.',
   })
   async getHealth(): Promise<HealthDto> {
     return this.service.getCruxHealth()

--- a/web/crux/src/app/image/image.http.controller.ts
+++ b/web/crux/src/app/image/image.http.controller.ts
@@ -68,10 +68,10 @@ export default class ImageHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      "Fetch details of an images within a version. `ProductId` refers to the product's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required variables.</br></br>Details come in an array, including `name`, `id`, `tag`, `order`, and config details of the image.",
+      "Fetch details of an images within a version. `productId` refers to the product's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required parameters.</br></br>An image consists `name`, `id`, `tag`, `order`, and config details of the image.",
     summary: 'Fetch data of an image of a version.',
   })
-  @ApiOkResponse({ type: ImageDto, description: 'Data of an image listed.' })
+  @ApiOkResponse({ type: ImageDto, description: 'Data of an image.' })
   @UuidParams(PARAM_PRODUCT_ID, PARAM_VERSION_ID, PARAM_IMAGE_ID)
   async getImageDetails(
     @ProductId() _productId: string,
@@ -86,8 +86,8 @@ export default class ImageHttpController {
   @CreatedWithLocation()
   @ApiOperation({
     description:
-      "Add new image to a version. `ProductId` refers to the product's ID, `versionId` refers to the version's ID, `registryId` refers to the registry's ID, `images` refers to the name(s) of the images you'd like to add. All are required variables.",
-    summary: 'Add an image to a version.',
+      "Add new images to a version. `productId` refers to the product's ID, `versionId` refers to the version's ID, `registryId` refers to the registry's ID, `images` refers to the name(s) of the images you'd like to add. All are required variables.",
+    summary: 'Add images to a version.',
   })
   @ApiBody({ type: AddImagesDto, isArray: true })
   @ApiCreatedResponse({ type: ImageDto, isArray: true, description: 'New image added.' })
@@ -112,11 +112,11 @@ export default class ImageHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      "Modify and add configuration variables of an image. `ProductId` refers to the product's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required variables. `Tag` refers to the version of the image, `config` is an array of configuration variables.",
+      "Modify the configuration variables of an image. `productId` refers to the product's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required variables. `Tag` refers to the version of the image, `config` is an object of configuration variables.",
     summary: 'Configure an image of a version.',
   })
   @ApiBody({ type: PatchImageDto })
-  @ApiNoContentResponse({ description: "Image's configure variables adjusted." })
+  @ApiNoContentResponse({ description: "Image's configure variables updated." })
   @UuidParams(PARAM_PRODUCT_ID, PARAM_VERSION_ID, PARAM_IMAGE_ID)
   async patchImage(
     @ProductId() _productId: string,
@@ -132,7 +132,7 @@ export default class ImageHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      "Delete an image. `ProductId` refers to the product's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required variables.",
+      "Delete an image. `productId` refers to the product's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required variables.",
     summary: 'Delete an image from a version.',
   })
   @ApiNoContentResponse({ description: 'Delete an image from a version.' })
@@ -150,10 +150,10 @@ export default class ImageHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      "Edit image deployment order of a version. `ProductId` refers to the product's ID, `versionId` refers to the version's ID. Both are required variables. Request should include the names of images in an array.",
+      "Edit image deployment order of a version. `productId` refers to the product's ID, `versionId` refers to the version's ID. Both are required variables. Request should include the IDs of the images in an array.",
     summary: 'Edit image deployment order of a version.',
   })
-  @ApiNoContentResponse({ description: 'Deployment order modified.' })
+  @ApiNoContentResponse({ description: 'Image order modified.' })
   @ApiBody({ type: String, isArray: true })
   @UseGuards(ImageOrderImagesTeamAccessGuard)
   @UseInterceptors(OrderImagesValidationInterceptor)

--- a/web/crux/src/app/image/image.http.controller.ts
+++ b/web/crux/src/app/image/image.http.controller.ts
@@ -68,7 +68,7 @@ export default class ImageHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      "Fetch details of an images within a version. `productId` refers to the product's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required parameters.</br></br>An image consists `name`, `id`, `tag`, `order`, and config details of the image.",
+      "Fetch details of an image within a version. `productId` refers to the product's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required parameters.</br></br>Image details consists `name`, `id`, `tag`, `order`, and the config of the image.",
     summary: 'Fetch data of an image of a version.',
   })
   @ApiOkResponse({ type: ImageDto, description: 'Data of an image.' })

--- a/web/crux/src/app/node/node.global-container.http.controller.ts
+++ b/web/crux/src/app/node/node.global-container.http.controller.ts
@@ -27,7 +27,7 @@ export default class NodeGlobalContainerHttpController {
   @ApiOperation({
     description:
       'Request must include `nodeId` and `prefix`. Response should include `id`, `command`, `createdAt`, `state`, `status`, `imageName`, `imageTag` and `ports` of images.',
-    summary: 'Fetch data of containers running on a node.',
+    summary: 'Fetch data of all containers on a node.',
   })
   @ApiOkResponse({ type: ContainerDto, isArray: true, description: 'Fetch data of containers running on a node.' })
   async getContainers(@NodeId() nodeId: string, @Query('prefix') prefix?: string): Promise<ContainerDto[]> {
@@ -38,7 +38,7 @@ export default class NodeGlobalContainerHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `nodeId`, and the `name` of the container.',
-    summary: 'Start any container on a node.',
+    summary: 'Start the specific container on a node.',
   })
   @ApiNoContentResponse({ description: 'Container started.' })
   @UuidParams(PARAM_NODE_ID)
@@ -50,7 +50,7 @@ export default class NodeGlobalContainerHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `nodeId`, and the `name` of the container.',
-    summary: 'Stop any container on a node.',
+    summary: 'Stop the specific container on a node.',
   })
   @ApiNoContentResponse({ description: 'Container stopped.' })
   @UuidParams(PARAM_NODE_ID)
@@ -62,7 +62,7 @@ export default class NodeGlobalContainerHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `nodeId`, and the `name` of the container.',
-    summary: 'Restart any container on a node.',
+    summary: 'Restart the specific container on a node.',
   })
   @ApiNoContentResponse({ description: 'Container restarted.' })
   @UuidParams(PARAM_NODE_ID)
@@ -74,7 +74,7 @@ export default class NodeGlobalContainerHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `nodeId`, and the `name` of the container.',
-    summary: 'Delete any container from a node.',
+    summary: 'Delete the specific container from a node.',
   })
   @ApiNoContentResponse({ description: 'Container deleted.' })
   @UuidParams(PARAM_NODE_ID)

--- a/web/crux/src/app/node/node.http.controller.ts
+++ b/web/crux/src/app/node/node.http.controller.ts
@@ -55,7 +55,7 @@ export default class NodeHttpController {
       "Fetch data of a specific node. Request must include `nodeId`. Response should include an array with the node's `type`, `status`, `description`, `icon`, `address`, `connectedAt` date, `version`, `updating`, `id`, `name`, `hasToken`, and agent installation details.",
     summary: 'Get data of nodes that belong to your team.',
   })
-  @ApiOkResponse({ type: NodeDetailsDto, description: 'Data of the node is listed.' })
+  @ApiOkResponse({ type: NodeDetailsDto, description: 'Data of the node.' })
   @UuidParams(PARAM_NODE_ID)
   async getNodeDetails(@NodeId() nodeId: string): Promise<NodeDetailsDto> {
     return this.service.getNodeDetails(nodeId)
@@ -146,7 +146,7 @@ export default class NodeHttpController {
       'Request must include `nodeId`. Response should include `type`, `status`, `description`, `icon`, `address`, `connectedAt` date, `version`, `updating`, `id`, `name`, `hasToken`, and `install` details.',
     summary: 'Fetch install script.',
   })
-  @ApiOkResponse({ type: NodeDetailsDto, description: 'Install script listed.' })
+  @ApiOkResponse({ type: NodeDetailsDto, description: 'Install script.' })
   @Header('content-type', 'text/plain')
   @DisableAuth()
   @UuidParams(PARAM_NODE_ID)
@@ -158,7 +158,7 @@ export default class NodeHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `nodeId`.',
-    summary: "Revoke token that belongs to a node's install script.",
+    summary: "Revoke the node's access token.",
   })
   @ApiNoContentResponse({ description: 'Token revoked.' })
   @UuidParams(PARAM_NODE_ID)

--- a/web/crux/src/app/node/node.prefix-container.http.controller.ts
+++ b/web/crux/src/app/node/node.prefix-container.http.controller.ts
@@ -62,7 +62,7 @@ export default class NodePrefixContainerHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `nodeId`, and `prefix`.',
-    summary: 'Delete containers deployed with dyrectorio on a node.',
+    summary: 'Delete containers deployed with dyrectorio, with the specified prefix on a node.',
   })
   @ApiNoContentResponse({ description: 'Containers deleted.' })
   @UuidParams(PARAM_NODE_ID)
@@ -74,7 +74,7 @@ export default class NodePrefixContainerHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `nodeId`, `prefix`, and `name`.',
-    summary: 'Delete a container deployed with dyrectorio on a node.',
+    summary: 'Delete a container deployed with dyrectorio, with the specified prefix and name on a node.',
   })
   @ApiNoContentResponse({ description: 'Container deleted.' })
   @UuidParams(PARAM_NODE_ID)

--- a/web/crux/src/app/notification/notification.http.controller.ts
+++ b/web/crux/src/app/notification/notification.http.controller.ts
@@ -48,7 +48,7 @@ export default class NotificationHttpController {
   @ApiOperation({
     description:
       'Request must include `notificationId` parameter. Response should include `type`, `enabledEvents`, `id`, `name`, `url`, `active`, and `creatorName`.',
-    summary: 'Fetch details of a notificatio.',
+    summary: 'Fetch details of a notification.',
   })
   @ApiOkResponse({ type: NotificationDetailsDto, description: 'Details of notification listed.' })
   async getNotificationDetails(@NotificationId() notificationId: string): Promise<NotificationDetailsDto> {

--- a/web/crux/src/app/notification/notification.http.controller.ts
+++ b/web/crux/src/app/notification/notification.http.controller.ts
@@ -38,7 +38,7 @@ export default class NotificationHttpController {
     description: 'Response should include `type`, `id`, `name`, `url`, `active`, and `creatorName`.',
     summary: 'Retrieve notifications that belong to a team.',
   })
-  @ApiOkResponse({ type: NotificationDto, isArray: true, description: 'Notification details listed.' })
+  @ApiOkResponse({ type: NotificationDto, isArray: true, description: 'Notifications listed.' })
   async getNotifications(@IdentityFromRequest() identity: Identity): Promise<NotificationDto[]> {
     return this.service.getNotifications(identity)
   }
@@ -48,9 +48,9 @@ export default class NotificationHttpController {
   @ApiOperation({
     description:
       'Request must include `notificationId` parameter. Response should include `type`, `enabledEvents`, `id`, `name`, `url`, `active`, and `creatorName`.',
-    summary: 'Fetch details of a notification.',
+    summary: 'Fetch details of a notificatio.',
   })
-  @ApiOkResponse({ type: NotificationDetailsDto, description: 'Data of notification listed.' })
+  @ApiOkResponse({ type: NotificationDetailsDto, description: 'Details of notification listed.' })
   async getNotificationDetails(@NotificationId() notificationId: string): Promise<NotificationDetailsDto> {
     return this.service.getNotificationDetails(notificationId)
   }

--- a/web/crux/src/app/product/product.http.controller.ts
+++ b/web/crux/src/app/product/product.http.controller.ts
@@ -33,17 +33,14 @@ export default class ProductHttpController {
   @HttpCode(200)
   @ApiOperation({
     description: "Returns a list of a team's products and their details.",
-    summary: 'Fetch details of products.',
+    summary: 'Fetch the products list.',
   })
   @ApiOkResponse({
     type: ProductListItemDto,
     isArray: true,
-    description: 'Everything is OK.',
+    description: 'List of products',
   })
   @ApiNoContentResponse()
-  @ApiBadRequestResponse({
-    description: 'Provided bad parmaters',
-  })
   async getProducts(@IdentityFromRequest() identity: Identity): Promise<ProductListItemDto[]> {
     return this.service.getProducts(identity)
   }
@@ -52,10 +49,10 @@ export default class ProductHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      "Returns a products' details. The response should contain an array, consisting of the product's `name`, `id`, `type`, `description`, `deletability`, versions and version related data, including version `name` and `id`, `changelog`, increasibility.",
+      "Returns a product's details. The response should contain an array, consisting of the product's `name`, `id`, `type`, `description`, `deletability`, versions and version related data, including version `name` and `id`, `changelog`, increasibility.",
     summary: 'Fetch details of a product.',
   })
-  @ApiOkResponse({ type: ProductDetailsDto, description: 'Everything is OK.' })
+  @ApiOkResponse({ type: ProductDetailsDto, description: 'Details of a product.' })
   @UuidParams(PARAM_PRODUCT_ID)
   async getProductDetails(@ProductId() id: string): Promise<ProductDetailsDto> {
     return this.service.getProductDetails(id)
@@ -87,7 +84,7 @@ export default class ProductHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      'Updates a product. `Name` is a required variable to identify which product is modified, `description` and `changelog` can be adjusted with this call.',
+      'Updates a product. `productId` is a required variable to identify which product is modified, `name`, `description` and `changelog` can be adjusted with this call.',
     summary: 'Update a product.',
   })
   @ApiNoContentResponse({ description: 'Product details are modified.' })
@@ -104,7 +101,7 @@ export default class ProductHttpController {
   @Delete(ROUTE_PRODUCT_ID)
   @HttpCode(204)
   @ApiOperation({
-    description: 'Deletes a product. Only the `name` is required.',
+    description: 'Deletes a product with the specified `productId`',
     summary: 'Delete a product.',
   })
   @ApiNoContentResponse({ description: 'Product deleted.' })

--- a/web/crux/src/app/product/product.http.controller.ts
+++ b/web/crux/src/app/product/product.http.controller.ts
@@ -1,6 +1,5 @@
 import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards, UseInterceptors } from '@nestjs/common'
 import {
-  ApiBadRequestResponse,
   ApiBody,
   ApiCreatedResponse,
   ApiNoContentResponse,

--- a/web/crux/src/app/registry/registry.http.controller.ts
+++ b/web/crux/src/app/registry/registry.http.controller.ts
@@ -37,7 +37,7 @@ export default class RegistryHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      'Lists the details of every registries available. Response is an array including the `name`, `id`, `type`, `description`, and `icon` of the registry.</br></br>Registries are 3rd party registries where the images of versions are located.',
+      'Lists every registries available in the active team. Response is an array including the `name`, `id`, `type`, `description`, and `icon` of the registry.</br></br>Registries are 3rd party registries where the container images are stored.',
     summary: 'Fetch data of registries.',
   })
   @ApiOkResponse({ type: RegistryDto, isArray: true, description: 'Data of all registries within a team listed.' })
@@ -49,7 +49,7 @@ export default class RegistryHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      "Lists the details of a registry. `RegistryId` refers to the registry's ID. Response is an array including the `name`, `id`, `type`, `description`, `imageNamePrefix`, `inUse`, `icon`, and audit log info of the registry.",
+      "Lists the details of a registry. `registryId` refers to the registry's ID. Response is an array including the `name`, `id`, `type`, `description`, `imageNamePrefix`, `inUse`, `icon`, and audit log info of the registry.",
     summary: 'Fetch data of a registry.',
   })
   @ApiOkResponse({ type: RegistryDetailsDto, description: 'Data of a registry listed.' })
@@ -64,13 +64,13 @@ export default class RegistryHttpController {
   @ApiOperation({
     description:
       'To add a new registry, include the `name`, `type`, `description`, `details`, and `icon`. `Type`, `details`, and `name` are required. Response is an array including the `name`, `id`, `type`, `description`, `imageNamePrefix`, `inUse`, `icon`, and audit log info of the registry.',
-    summary: 'Add a new registry.',
+    summary: 'Create a new registry.',
   })
   @ApiBody({ type: CreateRegistryDto })
   @ApiCreatedResponse({
     type: RegistryDetailsDto,
     headers: API_CREATED_LOCATION_HEADERS,
-    description: 'New registry added.',
+    description: 'New registry created.',
   })
   @UseGuards(RegistryAccessValidationGuard)
   async createRegistry(
@@ -89,13 +89,13 @@ export default class RegistryHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      "Modify the `name`, `type`, `description`, `details`, and `icon`. `RegistryId` refers to the registry's ID. `RegistryId`, `type`, `details`, and `name` are required.",
+      "Modify the `name`, `type`, `description`, `details`, and `icon`. `registryId` refers to the registry's ID. `registryId`, `type`, `details`, and `name` are required.",
     summary: 'Modify the details of a registry.',
   })
   @UseInterceptors(UpdateRegistryInterceptor)
   @UseGuards(RegistryAccessValidationGuard)
   @ApiBody({ type: UpdateRegistryDto })
-  @ApiNoContentResponse({ description: 'Details of registry modified.' })
+  @ApiNoContentResponse({ description: 'Registry modified.' })
   @UuidParams(PARAM_REGISTRY_ID)
   async updateRegistry(
     @RegistryId() id: string,
@@ -108,7 +108,7 @@ export default class RegistryHttpController {
   @Delete(ROUTE_REGISTRY_ID)
   @HttpCode(204)
   @ApiOperation({
-    description: 'To delete a registry from dyrectorio, only `RegistryId`, `type`, `details`, and `name` are required.',
+    description: 'Deletes a registry with the specified `registryId`',
     summary: 'Delete a registry from dyrectorio.',
   })
   @ApiNoContentResponse({ description: 'Registry deleted.' })

--- a/web/crux/src/app/storage/storage.http.controller.ts
+++ b/web/crux/src/app/storage/storage.http.controller.ts
@@ -4,8 +4,8 @@ import {
   ApiCreatedResponse,
   ApiNoContentResponse,
   ApiOkResponse,
-  ApiTags,
   ApiOperation,
+  ApiTags,
 } from '@nestjs/swagger'
 import { Identity } from '@ory/kratos-client'
 import UuidParams from 'src/decorators/api-params.decorator'
@@ -33,12 +33,12 @@ export default class StorageHttpController {
   @HttpCode(200)
   @ApiOperation({
     description: 'Response should include `description`, `icon`, `url`, `id`, and `name`.',
-    summary: 'Fetch details of storages.',
+    summary: 'Fetch the list of storages.',
   })
   @ApiOkResponse({
     type: StorageDto,
     isArray: true,
-    description: 'Details of storages listed.',
+    description: 'List of storages.',
   })
   async getStorages(@IdentityFromRequest() identity: Identity): Promise<StorageDto[]> {
     return this.service.getStorages(identity)
@@ -48,12 +48,12 @@ export default class StorageHttpController {
   @HttpCode(200)
   @ApiOperation({
     description: 'Response should include `id`, and `name`.',
-    summary: 'Fetch the name and ID of storages.',
+    summary: 'Fetch the name and ID of available storage options.',
   })
   @ApiOkResponse({
     type: StorageOptionDto,
     isArray: true,
-    description: 'Name and ID of storages listed.',
+    description: 'Name and ID of storage options listed.',
   })
   async getStorageOptions(@IdentityFromRequest() identity: Identity): Promise<StorageOptionDto[]> {
     return this.service.getStorageOptions(identity)
@@ -63,10 +63,10 @@ export default class StorageHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      'Request must include `storageId`. Response should include description, icon, url, `id`, `name`, `accessKey`, `secretKey`, and `inUse`.',
+      'Get the details of a storage. Request must include `storageId`. Response should include description, icon, url, `id`, `name`, `accessKey`, `secretKey`, and `inUse`.',
     summary: 'Return details of a storage.',
   })
-  @ApiOkResponse({ type: StorageDetailsDto, description: 'Storage details listed.' })
+  @ApiOkResponse({ type: StorageDetailsDto, description: 'Storage details.' })
   @UuidParams(PARAM_STORAGE_ID)
   async getProductDetails(@StorageId() id: string): Promise<StorageDetailsDto> {
     return this.service.getStorageDetails(id)
@@ -76,12 +76,12 @@ export default class StorageHttpController {
   @HttpCode(201)
   @ApiOperation({
     description:
-      'Request must include `name`, and `url`. Request body may include `description`, `icon`, `accesKey`, and `secretKey`. Response should include `description`, `icon`, `url`, `id`, `name`, `accessKey`, `secretKey`, and `inUse`.',
-    summary: 'Add a new storage.',
+      'Creates a new storage. Request must include `name`, and `url`. Request body may include `description`, `icon`, `accesKey`, and `secretKey`. Response should include `description`, `icon`, `url`, `id`, `name`, `accessKey`, `secretKey`, and `inUse`.',
+    summary: 'Create a new storage.',
   })
   @CreatedWithLocation()
   @ApiBody({ type: CreateStorageDto })
-  @ApiCreatedResponse({ type: StorageDetailsDto, description: 'New storage added.' })
+  @ApiCreatedResponse({ type: StorageDetailsDto, description: 'New storage created.' })
   async createProduct(
     @Body() request: CreateStorageDto,
     @IdentityFromRequest() identity: Identity,
@@ -98,7 +98,7 @@ export default class StorageHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      'Request must include `storageId`, `name`, and `url`. Request body may include `description`, `icon`, `accesKey`, and `secretKey`.',
+      'Updates a storage. Request must include `storageId`, `name`, and `url`. Request body may include `description`, `icon`, `accesKey`, and `secretKey`.',
     summary: 'Modify a storage.',
   })
   @UseInterceptors(StorageUpdateValidationInterceptor)
@@ -115,11 +115,11 @@ export default class StorageHttpController {
   @Delete(ROUTE_STORAGE_ID)
   @HttpCode(204)
   @ApiOperation({
-    description: 'Request must include `storageId`.',
-    summary: 'Remove a storage from dyrectorio.',
+    description: 'Deletes a storage Request must include `storageId`.',
+    summary: 'Delete a storage from dyrectorio.',
   })
   @UseInterceptors(StorageDeleteValidationInterceptor)
-  @ApiNoContentResponse({ description: 'Storage removed.' })
+  @ApiNoContentResponse({ description: 'Storage deleted.' })
   @UuidParams(PARAM_STORAGE_ID)
   async deleteProduct(@StorageId() id: string): Promise<void> {
     return this.service.deleteStorage(id)

--- a/web/crux/src/app/team/team.http.controller.ts
+++ b/web/crux/src/app/team/team.http.controller.ts
@@ -40,10 +40,10 @@ export default class TeamHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      'Data of teams consist of `name`, `id`, and `statistics`, including number of `users`, `products`, `nodes`, `versions`, and `deployments`.</br></br>Teams are the shared entity of multiple users. The purpose of teams is to separate users, nodes and products based on their needs within an organization. Team owners can assign roles. More details about teams here.',
+      'List of teams consist of `name`, `id`, and `statistics`, including number of `users`, `products`, `nodes`, `versions`, and `deployments`.</br></br>Teams are the shared entity of multiple users. The purpose of teams is to separate users, nodes and products based on their needs within an organization. Team owners can assign roles. More details about teams here.',
     summary: 'Fetch data of teams the user is a member of.',
   })
-  @ApiOkResponse({ type: TeamDto, isArray: true, description: 'Data of teams listed.' })
+  @ApiOkResponse({ type: TeamDto, isArray: true, description: 'List of teams and their statistics.' })
   @TeamRoleRequired('none')
   async getTeams(@IdentityFromRequest() identity: Identity): Promise<TeamDto[]> {
     return await this.service.getTeams(identity)
@@ -53,10 +53,10 @@ export default class TeamHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      "Request must include `teamId`, which is the ID of the team they'd like to get the data of. Data of teams consist of `name`, `id`, and `statistics`, including number of `users`, `products`, `nodes`, `versions`, and `deployments`. Response should include user details, as well, including `name`, `id`, `role`, `status`, `email`, and `lastLogin`.",
+      "Get the details of a team. Request must include `teamId`, which is the ID of the team they'd like to get the data of. Data of teams consist of `name`, `id`, and `statistics`, including number of `users`, `products`, `nodes`, `versions`, and `deployments`. Response should include user details, as well, including `name`, `id`, `role`, `status`, `email`, and `lastLogin`.",
     summary: 'Fetch data of a team the user is a member of.',
   })
-  @ApiOkResponse({ type: TeamDetailsDto, description: 'Data of the team is listed.' })
+  @ApiOkResponse({ type: TeamDetailsDto, description: 'Details of the team.' })
   @UuidParams(PARAM_TEAM_ID)
   async getTeamById(@TeamId() teamId: string): Promise<TeamDetailsDto> {
     return await this.service.getTeamById(teamId)
@@ -111,7 +111,7 @@ export default class TeamHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `teamId`. Owner access required for successful request.',
-    summary: 'Delete a team.',
+    summary: 'Deletes a team.',
   })
   @TeamRoleRequired('owner')
   @ApiNoContentResponse({ description: 'Team deleted.' })
@@ -127,14 +127,14 @@ export default class TeamHttpController {
   @CreatedWithLocation()
   @ApiOperation({
     description:
-      "Request must include `teamId`, email and `firstName`. Admin access required for successful request.</br></br>Response should include new user's `name`, `id`, `role`, `status`, `email`, and `lastLogin`.",
-    summary: 'Add new user to a team.',
+      "Request must include `teamId`, email and `firstName`. Admin access required for successful request.</br></br>Response should include new user's `name`, `id`, `role`, `status`, `email`, and `lastLogin`. Admin access required for successful request.",
+    summary: 'Invite a new user to the team.',
   })
   @ApiBody({ type: InviteUserDto })
   @ApiCreatedResponse({
     type: UserDto,
     headers: API_CREATED_LOCATION_HEADERS,
-    description: 'New user added.',
+    description: 'User invited.',
   })
   @UseInterceptors(TeamInviteUserValitationInterceptor)
   @TeamRoleRequired('admin')
@@ -156,7 +156,8 @@ export default class TeamHttpController {
   @HttpCode(204)
   @ApiBody({ type: UpdateUserRoleDto })
   @ApiOperation({
-    description: 'Request must include `teamId`, `userId` and `role`. Admin access required for successful request.',
+    description:
+      'Promotes or demotes the user. Request must include `teamId`, `userId` and `role`. Admin access required for successful request.',
     summary: 'Edit user role.',
   })
   @TeamRoleRequired('admin')
@@ -176,11 +177,12 @@ export default class TeamHttpController {
   @HttpCode(204)
   @TeamRoleRequired('admin')
   @ApiOperation({
-    description: 'Request must include `teamId`, `userId`. Admin access required for successful request.',
-    summary: 'Delete user from team.',
+    description:
+      'Removes the user from the team. Request must include `teamId`, `userId`. Admin access required for successful request.',
+    summary: 'Remove a user from the team.',
   })
   @UseInterceptors(TeamOwnerImmutabilityValidationInterceptor)
-  @ApiNoContentResponse({ description: 'User deleted from a team.' })
+  @ApiNoContentResponse({ description: 'User removed from a team.' })
   @UuidParams(PARAM_TEAM_ID, PARAM_USER_ID)
   async deleteUserFromTeam(@TeamId() teamId: string, @UserId() userId: string): Promise<void> {
     await this.service.deleteUserFromTeam(teamId, userId)

--- a/web/crux/src/app/team/team.http.controller.ts
+++ b/web/crux/src/app/team/team.http.controller.ts
@@ -93,7 +93,7 @@ export default class TeamHttpController {
   @HttpCode(204)
   @ApiBody({ type: UpdateTeamDto })
   @ApiOperation({
-    description: 'Request must include `teamId` and `name`. Admin access required for successful request.',
+    description: 'Request must include `teamId` and `name`. Admin access required for a successful request.',
     summary: "Modify a team's name.",
   })
   @TeamRoleRequired('admin')
@@ -127,7 +127,7 @@ export default class TeamHttpController {
   @CreatedWithLocation()
   @ApiOperation({
     description:
-      "Request must include `teamId`, email and `firstName`. Admin access required for successful request.</br></br>Response should include new user's `name`, `id`, `role`, `status`, `email`, and `lastLogin`. Admin access required for successful request.",
+      "Request must include `teamId`, email and `firstName`. Admin access required for a successful request.</br></br>Response should include new user's `name`, `id`, `role`, `status`, `email`, and `lastLogin`. Admin access required for a successful request.",
     summary: 'Invite a new user to the team.',
   })
   @ApiBody({ type: InviteUserDto })
@@ -157,7 +157,7 @@ export default class TeamHttpController {
   @ApiBody({ type: UpdateUserRoleDto })
   @ApiOperation({
     description:
-      'Promotes or demotes the user. Request must include `teamId`, `userId` and `role`. Admin access required for successful request.',
+      'Promotes or demotes the user. Request must include `teamId`, `userId` and `role`. Admin access required for a successful request.',
     summary: 'Edit user role.',
   })
   @TeamRoleRequired('admin')
@@ -178,7 +178,7 @@ export default class TeamHttpController {
   @TeamRoleRequired('admin')
   @ApiOperation({
     description:
-      'Removes the user from the team. Request must include `teamId`, `userId`. Admin access required for successful request.',
+      'Removes the user from the team. Request must include `teamId`, `userId`. Admin access required for a successful request.',
     summary: 'Remove a user from the team.',
   })
   @UseInterceptors(TeamOwnerImmutabilityValidationInterceptor)
@@ -193,7 +193,7 @@ export default class TeamHttpController {
   @UseInterceptors(TeamReinviteUserValidationInterceptor)
   @ApiOperation({
     description:
-      "This call sends a new invitation link to a user who hasn't accepted invitation to a team.</br></br>Request must include `teamId`, `userId`. Admin access required for successful request.",
+      "This call sends a new invitation link to a user who hasn't accepted invitation to a team.</br></br>Request must include `teamId`, `userId`. Admin access required for a successful request.",
     summary: 'Reinvite user with a pending invite status to a team.',
   })
   @TeamRoleRequired('admin')

--- a/web/crux/src/app/template/template.http.controller.ts
+++ b/web/crux/src/app/template/template.http.controller.ts
@@ -24,9 +24,9 @@ export default class TemplateHttpController {
   @HttpCode(200)
   @ApiOperation({
     description: 'Response should include `id`, `name`, `description` and `technologies` of templates.',
-    summary: 'Return details of templates on the platform.',
+    summary: 'Return list of templates on the platform.',
   })
-  @ApiOkResponse({ type: TemplateDto, isArray: true, description: 'Template details listed.' })
+  @ApiOkResponse({ type: TemplateDto, isArray: true, description: 'Templates listed.' })
   async getTemplates(): Promise<TemplateDto[]> {
     return this.templateFileService.getTemplates()
   }
@@ -40,7 +40,7 @@ export default class TemplateHttpController {
     summary: 'Creates a new product from the selected template.',
   })
   @ApiBody({ type: CreateProductFromTemplateDto })
-  @ApiCreatedResponse({ type: ProductDto, description: 'New template created.' })
+  @ApiCreatedResponse({ type: ProductDto, description: 'New product created.' })
   async createProduct(
     @Body() request: CreateProductFromTemplateDto,
     @IdentityFromRequest() identity: Identity,
@@ -57,7 +57,7 @@ export default class TemplateHttpController {
   @HttpCode(200)
   @ApiOperation({
     description: 'Request must include `templateId`.',
-    summary: 'Retrieves the image of the template',
+    summary: 'Retrieves the picture of the template',
   })
   @Header('content-type', 'image/jpeg')
   @ApiOkResponse({ description: 'Retrieve data of an image of a template.' })

--- a/web/crux/src/app/token/token.http.controller.ts
+++ b/web/crux/src/app/token/token.http.controller.ts
@@ -32,13 +32,13 @@ export default class TokenHttpController {
   @Get()
   @HttpCode(200)
   @ApiOperation({
-    description: "Access token's support is to provide secure access to a user's profile.",
-    summary: 'Retrieve access token.',
+    description: "Access token's support is to provide secure access to the HTTP api without a cookie.",
+    summary: 'List of tokens.',
   })
   @ApiOkResponse({
     type: TokenDto,
     isArray: true,
-    description: 'Token fetched.',
+    description: 'Token list fetched.',
   })
   async getTokens(@IdentityFromRequest() identity: Identity): Promise<TokenDto[]> {
     return this.service.getTokenList(identity)
@@ -85,7 +85,7 @@ export default class TokenHttpController {
   @HttpCode(204)
   @ApiOperation({
     description: 'Request must include `tokenId`.',
-    summary: 'Create access token.',
+    summary: 'Delete an access token.',
   })
   @ApiNoContentResponse({ description: 'Delete token.' })
   @UuidParams(PARAM_TOKEN_ID)

--- a/web/crux/src/app/version/version.http.controller.ts
+++ b/web/crux/src/app/version/version.http.controller.ts
@@ -39,13 +39,13 @@ export default class VersionHttpController {
   @HttpCode(200)
   @ApiOperation({
     description:
-      "Returns an array containing the details of every version that belong to a product. `ProductId` refers to the product's ID. Details include the version's `name`, `id`, `type`, `audit` log details, `changelog`, and increasibility.",
-    summary: 'Fetch the details of all the versions under a product.',
+      "Returns an array containing the every version that belong to a product. `productId` refers to the product's ID. Details include the version's `name`, `id`, `type`, `audit` log details, `changelog`, and increasibility.",
+    summary: 'Fetch the list of all the versions under a product.',
   })
   @ApiOkResponse({
     type: VersionDto,
     isArray: true,
-    description: 'Returns an array with the data of every version of a product.',
+    description: 'Returns an array with the every version of a product.',
   })
   @UuidParams(PARAM_PRODUCT_ID)
   async getVersions(@ProductId() productId: string, @IdentityFromRequest() identity: Identity): Promise<VersionDto[]> {
@@ -55,7 +55,7 @@ export default class VersionHttpController {
   @Get(ROUTE_VERSION_ID)
   @ApiOperation({
     description:
-      "Returns an array containing the details of every version that belong to a product. `ProductId` refers to the product's ID, `versionId` refers to the version's ID. Details include the version's `name`, `id`, `type`, `audit` log details, `changelog`, increasibility, mutability, deletability, and all image related data, including `name`, `id`, `tag`, `order` and configuration data of the images.",
+      "Returns the details of a version in the product. `productId` refers to the product's ID, `versionId` refers to the version's ID. Details include the version's `name`, `id`, `type`, `audit` log details, `changelog`, increasibility, mutability, deletability, and all image related data, including `name`, `id`, `tag`, `order` and configuration data of the images.",
     summary: 'Retrieve the details of a version of a product.',
   })
   @ApiOkResponse({ type: VersionDetailsDto, description: 'Details of a version under a product is fetched.' })
@@ -70,7 +70,7 @@ export default class VersionHttpController {
   @UseInterceptors(VersionCreateValidationInterceptor)
   @ApiOperation({
     description:
-      "Creates a new version to a product. `ProductId` refers to the product's ID. Request must include the `name` and `type` of the version, `changelog` is optionable. Response should include the `name`, `id`, `changelog`, increasibility, `type`, and `audit` log details of the version.",
+      "Creates a new version in a product. `productId` refers to the product's ID. Request must include the `name` and `type` of the version, `changelog` is optionable. Response should include the `name`, `id`, `changelog`, increasibility, `type`, and `audit` log details of the version.",
     summary: 'Create a new version.',
   })
   @ApiBody({ type: CreateVersionDto })
@@ -93,7 +93,7 @@ export default class VersionHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      "Updates a version's `changelog`. `ProductId` refers to the product's ID, `versionId` refers to the version's ID. Both are required variables.",
+      "Updates a version's `name` and `changelog`. `productId` refers to the product's ID, `versionId` refers to the version's ID. Both are required variables.",
     summary: 'Modify version.',
   })
   @ApiNoContentResponse({ description: 'Changelog of a version is updated.' })
@@ -113,7 +113,7 @@ export default class VersionHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      "This call deletes a version. `ProductId` refers to the product's ID, `versionId` refers to the version's ID. Both are required variables.",
+      "This call deletes a version. `productId` refers to the product's ID, `versionId` refers to the version's ID. Both are required variables.",
     summary: 'Delete a version.',
   })
   @ApiNoContentResponse({ description: 'Version deleted.' })
@@ -127,8 +127,9 @@ export default class VersionHttpController {
   @HttpCode(204)
   @ApiOperation({
     description:
-      "This call turns a version into a default one, resulting other versions within this product later inherit images and configurations from it. `ProductId` refers to the product's ID, `versionId` refers to the version's ID. Both are required variables.",
-    summary: 'Turn version into a default one of the complex product other versions under it will inherit images from.',
+      "This call turns a version into the default one, resulting other versions within this product later inherit images, deployments and their configurations from it. `productId` refers to the product's ID, `versionId` refers to the version's ID. Both are required variables.",
+    summary:
+      'Turn version into a default one of the complex product other versions under it will inherit images and deployments from.',
   })
   @ApiNoContentResponse({
     description: 'Version turned into default.',
@@ -143,8 +144,8 @@ export default class VersionHttpController {
   @CreatedWithLocation()
   @ApiOperation({
     description:
-      "Increases the default version of a product with a new version. `ProductId` refers to the product's ID, `versionId` refers to the version's ID, `name` refers to the name of the new version. All are required variables.",
-    summary: 'Increase a default version of a complex product with a new version.',
+      "Increases the version of a product with a new child version. `productId` refers to the product's ID, `versionId` refers to the version's ID, `name` refers to the name of the new version. All are required variables.",
+    summary: 'Increase a the version of a complex product with a new version.',
   })
   @UseInterceptors(VersionIncreaseValidationInterceptor)
   @ApiBody({ type: IncreaseVersionDto })


### PR DESCRIPTION
Remove `deployments/:deploymentId/events` as it was the duplication of `/log`
Improve api docs.