### PR TITLE
fix(ci): image builder

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -2,9 +2,9 @@ name: builder_image_builder_pipeline
 on:
   push:
     branches: [develop]
-    paths: [images/proto/**, .github/workflows/image-builder.yml]
+    paths: [images/alpine-proto/**, .github/workflows/image-builder.yml]
   pull_request:
-    paths: [images/proto/**, .github/workflows/image-builder.yml]
+    paths: [images/alpine-proto/**, .github/workflows/image-builder.yml]
 permissions:
   contents: read
   pull-requests: read
@@ -12,19 +12,19 @@ permissions:
 env:
   GITHUB_REGISTRY: ghcr.io
   BUILDER_IMAGE_NAME: dyrector-io/dyrectorio/alpine-proto
-  VERSION: 3.16-5
+  VERSION: 3.17-4
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/dyrector-io/dyrectorio/alpine-proto:3.17-3
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Docker build
-        run: docker build -f ./images/alpine-proto/Dockerfile -t ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION} .
-      - name: Docker save
-        run: docker save ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION} | gzip -f > builder.zstd
+      - name: Add requirements and build the image
+        run: |
+          sudo apt update
+          sudo apt install zstd golang docker.io containerd runc
+          docker build -f ./images/alpine-proto/Dockerfile -t ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION} .
+          docker save ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION} | gzip -f > builder.zstd
       - name: artifact upload
         uses: actions/upload-artifact@v3
         with:
@@ -33,8 +33,6 @@ jobs:
   push:
     runs-on: ubuntu-22.04
     needs: build
-    container:
-      image: ghcr.io/dyrector-io/dyrectorio/alpine-proto:3.17-3
     if: github.ref_name == 'develop'
     environment: Workflow - Protected
     steps:
@@ -43,8 +41,12 @@ jobs:
         with:
           name: builder
           path: artifacts
-      - name: Docker load
-        run: zcat artifacts/builder.zstd | docker load
+      - name: Add requirements
+        run: |
+          sudo apt update
+          sudo apt install zstd golang docker.io containerd runc
+          go install github.com/sigstore/cosign/v2/cmd/cosign@v2.0.2
+          zcat artifacts/builder.zstd | docker load
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:
@@ -57,6 +59,6 @@ jobs:
         run: echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
       - name: Sign container image
         run: |
-          cosign sign --key cosign.key ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION}
+          ~/go/bin/cosign sign --key cosign.key ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION}
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -106,7 +106,6 @@ install-cli: single-arch-check compile-cli
 	endif
 	cp build/out/cli-$(GOARCHS) $(GOBIN)/
 
-
 .PHONY: compile-crane
 compile-crane:
 	cd cmd/crane && \
@@ -119,12 +118,11 @@ compile-dagent:
 
 .PHONY: install-go-tools
 install-go-tools:
-	go install github.com/cosmtrek/air@${GOAIR} && \
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI} && \
+	go install github.com/cosmtrek/air@${GOAIR}
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI}
 	go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC}
 	go install mvdan.cc/gofumpt@${GOFUMPT}
 	go install github.com/google/yamlfmt/cmd/yamlfmt@${YAMLFMT}
-
 
 .PHONY: compile-agents
 compile-agents: compile-crane compile-dagent

--- a/images/alpine-proto/Dockerfile
+++ b/images/alpine-proto/Dockerfile
@@ -1,6 +1,6 @@
 # this image is our official way of generating proto-files
 # for reproducable builds, anywhere
-FROM golang:1.20-alpine3.17
+FROM docker.io/library/golang:1.20-alpine3.17
 
 ENV GOLANGCI_LINT_CACHE $GOPATH/cache
 ENV GOCACHE $GOPATH/cache


### PR DESCRIPTION
This PR resolves some discrepancy around building the "builder image"

This PR resolves the chicken-egg issue in the pipeline by removing the builder image, but using a "bare" VM to install the few stuff we need and build/push/sign the image.