### PR TITLE
docs: add CLI docs link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Stack:
 
 1. Read the CLI documentation first (See the end of this section)
 2. Decide which part of the project you want to work on, in this case it is crux, crux-ui or both
-3. Modify the CLI's settings file if necessary
+3. Modify the [CLI's settings file](https://docs.dyrector.io/get-started/cli#configuration) if necessary
 4. Execute the correct CLI command using the appropriate flags to turn off crux or crux-ui services
 5. Start crux or crux-ui with the appropriate `npm` command, usually `npm run start`
 6. After you navigated to `localhost:8000` (this is the default Traefik port) you will see a Login screen

--- a/web/crux/README.md
+++ b/web/crux/README.md
@@ -5,20 +5,26 @@ information or check our official [documentation](https://docs.dyrector.io/) sit
 
 ## Project structure
 
-- `certs/` - Generated certificates, created for testing and local development purpose
+- `assets/` - TBD
 - `prisma/`
   - `/migrations` - Your migration history is the story of the changes to your data model, and is represented by a this
     folder with a sub-folder and migration.sql file for each migration.
-- `/proto` - gRPC proto files for communicate against the `dagent` and `crux-ui`
-- `/scripts` - every development related script
-- `/containerization ` -
-- `/src` -
+- `/proto` - gRPC proto files for communicate against the `agent`
+- `/src`
+
   - `/app` - NestJS core application, each model has it's own folder with service, controller and repository serivces.
-  - `/config` - Config related files
-  - `/domain` - Internal logic of the application
-  - `/exception` - Errors and Exceptions
-  - `/proto` - Generated proto typescript from .proto files
-  - `/shared` - NestJS shared resources
+  - `builders/` -
+  - `decorators/` -
+  - `domain/` - Internal logic of the application
+  - `exception/` - Errors and Exceptions
+  - `filters/` - Custom filters
+  - `grpc/` -
+  - `guards/` - Custom guards
+  - `interceptors/` -
+  - `mailer/` -
+  - `services/` -
+  - `shared/` - NestJS shared resources
+  - `websockets/` -
 
 ## Technology stack
 


### PR DESCRIPTION
PR contains:
- Link the appropriate section to CLI config
- Update the `crux/README.md`