### PR TITLE
doc(kratos): fix more info link

### DIFF
--- a/web/kratos/README.md
+++ b/web/kratos/README.md
@@ -158,4 +158,4 @@ sent by kratos. You can access it from your browser at http://0.0.0.0:4436
 
 ## More info about kratos
 
-https://www.ory.sh/kratos/docs/concepts/index
+https://www.ory.sh/docs/kratos


### PR DESCRIPTION
This link no longer exists (results in 404: NOT_FOUND):
https://www.ory.sh/kratos/docs/concepts/index

Corrected to:
https://www.ory.sh/docs/kratos