### PR TITLE
feat(ci): add auto assignes to PR

### DIFF
--- a/.github/config/auto-assign.yml
+++ b/.github/config/auto-assign.yml
@@ -1,3 +1,2 @@
 addAssignees: author
-
 runOnDraft: true

--- a/.github/config/auto-assign.yml
+++ b/.github/config/auto-assign.yml
@@ -1,12 +1,9 @@
 addAssignees: author
-
 addReviewers: true
-
 reviewers:
   - m8vago
   - robot9706
   - polaroi8d
   - nandor-magyar
   - c3ppc3pp
-
 runOnDraft: true

--- a/.github/config/auto-assign.yml
+++ b/.github/config/auto-assign.yml
@@ -1,0 +1,12 @@
+addAssignees: author
+
+addReviewers: true
+
+reviewers:
+  - m8vago
+  - robot9706
+  - polaroi8d
+  - nandor-magyar
+  - c3ppc3pp
+
+runOnDraft: true

--- a/.github/config/auto-assign.yml
+++ b/.github/config/auto-assign.yml
@@ -1,9 +1,3 @@
 addAssignees: author
-addReviewers: true
-reviewers:
-  - m8vago
-  - robot9706
-  - polaroi8d
-  - nandor-magyar
-  - c3ppc3pp
+
 runOnDraft: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -24,6 +24,15 @@ jobs:
             echo "Pull Request is from a forked repository."
             echo "fork=true" >> $GITHUB_OUTPUT
           fi
+  # Auto assigne reviewers and PR author
+  add-reviews:
+    runs-on: ubuntu-latest
+    if: ${{ needs.check_repository_origin.outputs.fork == 'false' }}
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/config/auto-assign.yml'
+
   # Add source labels to the PR
   label_based_on_source_lang:
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -26,13 +26,15 @@ jobs:
           fi
   # Auto assigne reviewers and PR author
   add-reviews:
-    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-22.04
     if: ${{ needs.check_repository_origin.outputs.fork == 'false' }}
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
-          configuration-path: '.github/config/auto-assign.yml'
-
+          configuration-path: .github/config/auto-assign.yml
   # Add source labels to the PR
   label_based_on_source_lang:
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -26,9 +26,7 @@ jobs:
           fi
   # Auto assigne reviewers and PR author
   add-reviews:
-    permissions:
-      contents: read
-      pull-requests: write
+    needs: check_repository_origin
     runs-on: ubuntu-22.04
     if: ${{ needs.check_repository_origin.outputs.fork == 'false' }}
     steps:


### PR DESCRIPTION
Add an action that will assign the author of the PR to the Assignees. This action should only work with non-forked repositories due to security concerns.