### PR TITLE
fix(crux): nullpointer in ContainerStateMessage mapping

### DIFF
--- a/web/crux/src/app/node/node.mapper.ts
+++ b/web/crux/src/app/node/node.mapper.ts
@@ -96,14 +96,15 @@ export default class NodeMapper {
   containerStateMessageToContainerMessage(list: ContainerStateListMessage): ContainersStateListMessage {
     return {
       prefix: list.prefix ?? '',
-      containers: list.data.map(it => ({
-        id: it.id,
-        imageName: it.imageName,
-        imageTag: it.imageTag,
-        ports: it.ports,
-        state: this.containerStateToDto(it.state),
-        date: fromTimestamp(it.createdAt),
-      })),
+      containers:
+        list.data?.map(it => ({
+          id: it.id,
+          imageName: it.imageName,
+          imageTag: it.imageTag,
+          ports: it.ports,
+          state: this.containerStateToDto(it.state),
+          date: fromTimestamp(it.createdAt),
+        })) ?? [],
     }
   }
 


### PR DESCRIPTION
Fixes an unhandled exception in prod

```
[Nest] 19  - 05/17/2023, 10:13:05 AM   ERROR [WsExceptionFilter] Unhandled Exception
[Nest] 19  - 05/17/2023, 10:13:05 AM   ERROR [WsExceptionFilter] TypeError: Cannot read properties of undefined (reading 'map')
TypeError: Cannot read properties of undefined (reading 'map')
    at NodeMapper.containerStateMessageToContainerMessage (/app/dist/app/node/node.mapper.js:54:35)
    at /app/dist/app/node/node.service.js:162:110
    at /app/node_modules/rxjs/dist/cjs/internal/operators/map.js:10:37
    at OperatorSubscriber._this._next (/app/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js:33:21)
    at Subscriber.next (/app/node_modules/rxjs/dist/cjs/internal/Subscriber.js:51:18)
    at /app/node_modules/rxjs/dist/cjs/internal/operators/mergeInternals.js:28:28
    at OperatorSubscriber._this._next (/app/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js:33:21)
    at Subscriber.next (/app/node_modules/rxjs/dist/cjs/internal/Subscriber.js:51:18)
    at /app/node_modules/rxjs/dist/cjs/internal/Subject.js:69:34
    at Object.errorContext (/app/node_modules/rxjs/dist/cjs/internal/util/errorContext.js:22:9)
[Nest] 19  - 05/17/2023, 10:13:05 AM   ERROR [WsExceptionFilter] 500 {"message":"UnhandledException"}

```