### PR TITLE
feat(crux): use proxy headers to determine the node ip

### DIFF
--- a/web/crux/src/app/agent/agent.service.ts
+++ b/web/crux/src/app/agent/agent.service.ts
@@ -183,7 +183,7 @@ export default class AgentService {
   ): Observable<Empty> {
     const agent = this.getByIdOrThrow(connection.nodeId)
 
-    const deploymentId = connection.getMetaData(GrpcNodeConnection.META_DEPLOYMENT_ID)
+    const deploymentId = connection.getStringMetadataOrThrow(GrpcNodeConnection.META_DEPLOYMENT_ID)
     this.logger.debug(`Opening deployment status channel: ${deploymentId}`)
 
     const deployment = agent.getDeployment(deploymentId)
@@ -228,7 +228,7 @@ export default class AgentService {
     request: Observable<ContainerStateListMessage>,
   ): Observable<Empty> {
     const agent = this.getByIdOrThrow(connection.nodeId)
-    const prefix = connection.getMetaData(GrpcNodeConnection.META_FILTER_PREFIX)
+    const prefix = connection.getStringMetadataOrThrow(GrpcNodeConnection.META_FILTER_PREFIX)
 
     const [watcher, completer] = agent.onContainerStateStreamStarted(prefix)
     if (!watcher) {
@@ -294,8 +294,8 @@ export default class AgentService {
   handleContainerLog(connection: GrpcNodeConnection, request: Observable<ContainerLogMessage>): Observable<Empty> {
     const agent = this.getByIdOrThrow(connection.nodeId)
 
-    const containerPrefix = connection.getMetaDataOrDefault(GrpcNodeConnection.META_CONTAINER_PREFIX)
-    const containerName = connection.getMetaDataOrDefault(GrpcNodeConnection.META_CONTAINER_NAME)
+    const containerPrefix = connection.getStringMetadata(GrpcNodeConnection.META_CONTAINER_PREFIX)
+    const containerName = connection.getStringMetadata(GrpcNodeConnection.META_CONTAINER_NAME)
 
     const container: ContainerIdentifier = {
       prefix: containerPrefix ?? '',

--- a/web/crux/src/main.ts
+++ b/web/crux/src/main.ts
@@ -24,10 +24,8 @@ type GrpcOptions = {
   credentials: ServerCredentials
 }
 
-type GrpcClient = 'api' | 'agent'
-
-const loadGrpcOptions = (certPrefix: GrpcClient, portEnv: string): GrpcOptions => {
-  const port = portEnv ? Number(portEnv) : certPrefix === 'agent' ? 5000 : 5001
+const loadGrpcOptions = (portEnv: string): GrpcOptions => {
+  const port = portEnv ? Number(portEnv) : 5000
 
   return {
     // tls termination occurs at the reverse proxy
@@ -58,7 +56,7 @@ const bootstrap = async () => {
   const document = SwaggerModule.createDocument(app, config)
   SwaggerModule.setup('/api/swagger', app, document)
 
-  const agentOptions = loadGrpcOptions('agent', configService.get<string>('GRPC_AGENT_PORT'))
+  const agentOptions = loadGrpcOptions(configService.get<string>('GRPC_AGENT_PORT'))
   const httpOptions = configService.get<string>('HTTP_API_PORT', '1848')
 
   const authGuard = app.get(JwtAuthGuard)

--- a/web/crux/src/shared/grpc-node-connection.spec.ts
+++ b/web/crux/src/shared/grpc-node-connection.spec.ts
@@ -1,6 +1,5 @@
 import { Metadata } from '@grpc/grpc-js'
 import GrpcNodeConnection, { NodeGrpcCall } from './grpc-node-connection'
-import exp from 'constants'
 
 describe('GrpcNodeConnection', () => {
   let call: NodeGrpcCall

--- a/web/crux/src/shared/grpc-node-connection.spec.ts
+++ b/web/crux/src/shared/grpc-node-connection.spec.ts
@@ -1,0 +1,71 @@
+import { Metadata } from '@grpc/grpc-js'
+import GrpcNodeConnection, { NodeGrpcCall } from './grpc-node-connection'
+import exp from 'constants'
+
+describe('GrpcNodeConnection', () => {
+  let call: NodeGrpcCall
+  let metadata: Metadata
+
+  beforeEach(() => {
+    call = {} as NodeGrpcCall
+    call.call = {
+      handler: {
+        type: 'bidi',
+      },
+    }
+    call.on = jest.fn()
+    call.getPeer = jest.fn(() => 'peer-ip')
+
+    metadata = new Metadata()
+    metadata.set(GrpcNodeConnection.META_NODE_TOKEN, 'node-token')
+  })
+
+  it('should use the x-real-ip metadata when available', () => {
+    const expected = '1.2.3.4'
+
+    metadata.add('x-real-ip', expected)
+
+    const connection = new GrpcNodeConnection(metadata, call)
+
+    const actual = connection.address
+
+    expect(actual).toBe(expected)
+  })
+
+  it('should use the x-forwarded-for metadata when available', () => {
+    const expected = '1.2.3.4'
+
+    metadata.add('x-forwarded-for', expected)
+
+    const connection = new GrpcNodeConnection(metadata, call)
+
+    const actual = connection.address
+
+    expect(actual).toBe(expected)
+  })
+
+  it('should prefer x-real-ip over x-forwarded-for metadata when available', () => {
+    const expected = '1.2.3.4'
+
+    metadata.add('x-real-ip', expected)
+    metadata.add('x-forwarded-for', 'forwarded-for-ip')
+
+    const connection = new GrpcNodeConnection(metadata, call)
+
+    const actual = connection.address
+
+    expect(actual).toBe(expected)
+  })
+
+  it("should fall back to call's peer, when no proxy headers available", () => {
+    const expected = '1.2.3.4'
+
+    call.getPeer = jest.fn(() => expected)
+
+    const connection = new GrpcNodeConnection(metadata, call)
+
+    const actual = connection.address
+
+    expect(actual).toBe(expected)
+  })
+})


### PR DESCRIPTION
Take proxy headers into account while determining the address of a node.