### PR TITLE
fix(dagent): remove agent install non-POSIX parts

### DIFF
--- a/web/crux/assets/install-script/install-docker.sh.hbr
+++ b/web/crux/assets/install-script/install-docker.sh.hbr
@@ -98,7 +98,7 @@ set_environment() {
       HOST_DOCKER_SOCK_PATH="/var/run/docker.sock"
     else
       if [ $(echo "$DOCKER_HOST" | cut -b -7) = "unix://" ]; then
-        HOST_DOCKER_SOCK_PATH="$DOCKER_HOST"
+        HOST_DOCKER_SOCK_PATH=$(echo "$DOCKER_HOST" | cut -b 7-)
       else
         echo "Invalid DOCKER_HOST variable please set HOST_DOCKER_SOCK_PATH if your socket is in a custom location otherwise unset DOCKER_HOST!"
         exit 1


### PR DESCRIPTION
We've been setting up docker agents various distros and sites it shows clearly that non-POSIX shell interpreter usage causes problems.

I've ran the shellcheck linter and adjusted the scripts as suggested. In order to avoid future shell issues I would suggest to those who uses other shells on Linux machines than dash/yash to install one of these and override the distribution symlink (in case of Arch especially).  @m8vago @c3ppc3pp

https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck
https://github.com/itspriddle/vim-shellcheck