### PR TITLE
fix(dagent): correct logDriver mapping

### DIFF
--- a/golang/internal/mapper/grpc.go
+++ b/golang/internal/mapper/grpc.go
@@ -151,7 +151,7 @@ func mapDagentConfig(dagent *agent.DagentContainerConfig, containerConfig *v1.Co
 
 	if dagent.LogConfig != nil {
 		containerConfig.LogConfig = &container.LogConfig{
-			Type:   dagent.LogConfig.Driver.String(),
+			Type:   strings.ToLower(dagent.LogConfig.Driver.String()),
 			Config: dagent.LogConfig.Options,
 		}
 	}


### PR DESCRIPTION
The problem was that from gRPC when parsing it `field.toString` function create capitalized strings that is not valid as a docker log option.