### PR TITLE
fix(crux): add https if protocol is missing from storage URL

### DIFF
--- a/web/crux-ui/src/components/storages/edit-storage-card.tsx
+++ b/web/crux-ui/src/components/storages/edit-storage-card.tsx
@@ -132,6 +132,7 @@ const EditStorageCard = (props: EditStorageCardProps) => {
             grow
             name="url"
             type="text"
+            placeholder="https://example.com"
             label={t('url')}
             onChange={formik.handleChange}
             value={formik.values.url}

--- a/web/crux/src/app/deploy/deploy.mapper.ts
+++ b/web/crux/src/app/deploy/deploy.mapper.ts
@@ -381,10 +381,11 @@ export default class DeployMapper {
   }
 
   private storageToImportContainer(config: MergedContainerConfigData, storage: Storage): ImportContainer {
+    const url = /^(http)s?/.test(storage.url) ? storage.url : `https://${storage.url}`
     let environment: { [key: string]: string } = {
       RCLONE_CONFIG_S3_TYPE: 's3',
       RCLONE_CONFIG_S3_PROVIDER: 'Other',
-      RCLONE_CONFIG_S3_ENDPOINT: storage.url,
+      RCLONE_CONFIG_S3_ENDPOINT: url,
     }
     if (storage.accessKey && storage.secretKey) {
       environment = {


### PR DESCRIPTION
Added default https, untouched if http or https defined, tests included.