### PR TITLE
fix: project creation navigation, remove playwright retries, small fixes

### DIFF
--- a/web/crux-ui/e2e/utils/projects.ts
+++ b/web/crux-ui/e2e/utils/projects.ts
@@ -16,9 +16,6 @@ export const createProject = async (page: Page, name: string, type: ProjectType)
 
   await page.locator('button:has-text("Save")').click()
 
-  const project = await page.waitForSelector(`a:has-text("${name}")`)
-
-  await project.click()
   await page.waitForURL(`${ROUTE_PROJECTS}/**`)
 
   if (type === 'versionless') {

--- a/web/crux-ui/playwright.config.ts
+++ b/web/crux-ui/playwright.config.ts
@@ -12,11 +12,9 @@ const baseURL = process.env.E2E_BASE_URL || 'http://localhost:8000'
 const config: PlaywrightTestConfig = {
   globalSetup: path.join(__dirname, 'e2e', 'utils', 'global-setup.ts'),
   globalTeardown: path.join(__dirname, 'e2e', 'utils', 'global-teardown.ts'),
-  timeout: 2 * 60 * 1000, // 2 min
-  expect: { timeout: 10 * 1000 }, // We double the default(5s), since some test runners are not THAT fast :)
+  timeout: 2 * 60 * 1000, // 2 minutes
+  expect: { timeout: 10 * 1000 }, // We double the default(5s), since some test runners are not that fast
   testDir: path.join(__dirname, 'e2e'),
-  // With 3 retries it runs for ages on the pipeline. One is the sweet spot.
-  retries: 1,
   // Artifacts folder where screenshots, videos, and traces are stored.
   outputDir: path.join(__dirname, 'e2e_results/'),
   webServer: {

--- a/web/crux-ui/src/components/projects/edit-project-card.tsx
+++ b/web/crux-ui/src/components/projects/edit-project-card.tsx
@@ -13,6 +13,7 @@ import { API_PROJECTS, projectApiUrl } from '@app/routes'
 import { sendForm } from '@app/utils'
 import { createProjectSchema, updateProjectSchema } from '@app/validations'
 import useTranslation from 'next-translate/useTranslation'
+import { useRouter } from 'next/router'
 import { MutableRefObject, useState } from 'react'
 
 interface EditProjectCardProps {
@@ -26,6 +27,7 @@ const EditProjectCard = (props: EditProjectCardProps) => {
   const { project: propsProject, className, onProjectEdited, submitRef } = props
 
   const { t } = useTranslation('projects')
+  const router = useRouter()
 
   const [project, setProject] = useState<EditableProject>(
     propsProject ?? {

--- a/web/crux-ui/src/components/projects/edit-project-card.tsx
+++ b/web/crux-ui/src/components/projects/edit-project-card.tsx
@@ -13,7 +13,6 @@ import { API_PROJECTS, projectApiUrl } from '@app/routes'
 import { sendForm } from '@app/utils'
 import { createProjectSchema, updateProjectSchema } from '@app/validations'
 import useTranslation from 'next-translate/useTranslation'
-import { useRouter } from 'next/router'
 import { MutableRefObject, useState } from 'react'
 
 interface EditProjectCardProps {
@@ -27,7 +26,6 @@ const EditProjectCard = (props: EditProjectCardProps) => {
   const { project: propsProject, className, onProjectEdited, submitRef } = props
 
   const { t } = useTranslation('projects')
-  const router = useRouter()
 
   const [project, setProject] = useState<EditableProject>(
     propsProject ?? {

--- a/web/crux-ui/src/pages/deployments.tsx
+++ b/web/crux-ui/src/pages/deployments.tsx
@@ -81,12 +81,12 @@ const DeploymentsPage = (props: DeploymentsPageProps) => {
     clsx('text-center rounded-tr-lg', defaultHeaderClass),
   ]
 
-  const onCellClick = (data: Deployment, row: number, col: number) => {
+  const onCellClick = async (data: Deployment, row: number, col: number) => {
     if (col >= headers.length - 1) {
       return
     }
 
-    router.push(deploymentUrl(data.id))
+    await router.push(deploymentUrl(data.id))
   }
 
   const itemTemplate = (item: Deployment) => /* eslint-disable react/jsx-key */ [

--- a/web/crux-ui/src/pages/nodes/[nodeId].tsx
+++ b/web/crux-ui/src/pages/nodes/[nodeId].tsx
@@ -55,7 +55,7 @@ const NodeDetailsPage = (props: NodeDetailsPageProps) => {
     }
 
     await mutate(API_NODES, null)
-    router.push(ROUTE_NODES)
+    await router.push(ROUTE_NODES)
   }
 
   const pageLink: BreadcrumbLink = {

--- a/web/crux-ui/src/pages/projects.tsx
+++ b/web/crux-ui/src/pages/projects.tsx
@@ -11,11 +11,12 @@ import DyoFilterChips from '@app/elements/dyo-filter-chips'
 import { DyoHeading } from '@app/elements/dyo-heading'
 import { TextFilter, textFilterFor, useFilters } from '@app/hooks/use-filters'
 import { Project, ProjectType, PROJECT_TYPE_VALUES } from '@app/models'
-import { API_PROJECTS, ROUTE_PROJECTS } from '@app/routes'
+import { API_PROJECTS, projectUrl, ROUTE_PROJECTS } from '@app/routes'
 import { auditToLocaleDate, withContextAuthorization } from '@app/utils'
 import { getCruxFromContext } from '@server/crux-api'
 import { NextPageContext } from 'next'
 import useTranslation from 'next-translate/useTranslation'
+import { useRouter } from 'next/router'
 import { useRef, useState } from 'react'
 
 type ProjectFilter = TextFilter & {
@@ -36,6 +37,7 @@ interface ProjectsPageProps {
 const ProjectsPage = (props: ProjectsPageProps) => {
   const { projects } = props
 
+  const router = useRouter()
   const { t } = useTranslation('projects')
 
   const filters = useFilters<Project, ProjectFilter>({
@@ -54,6 +56,9 @@ const ProjectsPage = (props: ProjectsPageProps) => {
   const onCreated = (project: Project) => {
     setCreating(false)
     filters.setItems([...filters.items, project])
+
+    // When creating navigate the user to the project detail page
+    router.push(projectUrl(project.id))
   }
 
   const pageLink: BreadcrumbLink = {

--- a/web/crux-ui/src/pages/projects.tsx
+++ b/web/crux-ui/src/pages/projects.tsx
@@ -53,12 +53,12 @@ const ProjectsPage = (props: ProjectsPageProps) => {
 
   const [viewMode, setViewMode] = useState<ViewMode>('tile')
 
-  const onCreated = (project: Project) => {
+  const onCreated = async (project: Project) => {
     setCreating(false)
     filters.setItems([...filters.items, project])
 
     // When creating navigate the user to the project detail page
-    router.push(projectUrl(project.id))
+    await router.push(projectUrl(project.id))
   }
 
   const pageLink: BreadcrumbLink = {

--- a/web/crux/prisma/schema.prisma
+++ b/web/crux/prisma/schema.prisma
@@ -275,10 +275,10 @@ model Deployment {
 }
 
 model Instance {
-  id           String              @id @default(uuid()) @db.Uuid
-  updatedAt    DateTime            @updatedAt @db.Timestamptz(6)
-  deploymentId String              @db.Uuid
-  imageId      String              @db.Uuid
+  id           String   @id @default(uuid()) @db.Uuid
+  updatedAt    DateTime @updatedAt @db.Timestamptz(6)
+  deploymentId String   @db.Uuid
+  imageId      String   @db.Uuid
 
   deployment Deployment               @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
   image      Image                    @relation(fields: [imageId], references: [id], onDelete: Cascade)
@@ -357,10 +357,10 @@ enum AuditLogRequestMethodEnum {
 }
 
 model AuditLog {
-  id        String                    @id @default(uuid()) @db.Uuid
-  createdAt DateTime                  @default(now()) @db.Timestamptz(6)
-  userId    String                    @db.Uuid
-  teamId    String                    @db.Uuid
+  id        String                     @id @default(uuid()) @db.Uuid
+  createdAt DateTime                   @default(now()) @db.Timestamptz(6)
+  userId    String                     @db.Uuid
+  teamId    String                     @db.Uuid
   context   AuditLogContextEnum
   method    AuditLogRequestMethodEnum?
   event     String
@@ -405,13 +405,13 @@ model NotificationEvent {
 }
 
 model AgentEvent {
-  id             String               @id @default(uuid()) @db.Uuid
-  nodeId         String               @db.Uuid
-  createdAt      DateTime             @default(now()) @db.Timestamptz(6)
-  event          AgentEventTypeEnum
-  data           Json?
+  id        String             @id @default(uuid()) @db.Uuid
+  nodeId    String             @db.Uuid
+  createdAt DateTime           @default(now()) @db.Timestamptz(6)
+  event     AgentEventTypeEnum
+  data      Json?
 
-  node Node @relation(fields: [nodeId], references: [id], onDelete: Cascade)  
+  node Node @relation(fields: [nodeId], references: [id], onDelete: Cascade)
 }
 
 enum ProjectTypeEnum {


### PR DESCRIPTION
PR contains the following improvement: When the user creates a new project, now the platform navigates to the project detail page instead of the project list page. 