### PR TITLE
feat(web): add extra explanation to dagent persistence section

### DIFF
--- a/web/crux-ui/locales/en/nodes.json
+++ b/web/crux-ui/locales/en/nodes.json
@@ -49,7 +49,7 @@
     "unreachable": "Unreachable"
   },
   "persistentDataPath": "Persistent data path",
-  "persistentDataExplanation": "This is where agent will create and store some files required to work as well as create persistent storage for containers.",
+  "persistentDataExplanation": "Stores basic operational data and serves as a base path for containers using relative volume names. Environment variables are resolved, but it is suggested to use absolute paths and avoid special characters.",
   "optionalLeaveEmptyForDefaults": "Optional, leave empty for default paths",
   "update": "Update",
   "updateError": "Failed to update agent: {{error}}",


### PR DESCRIPTION
Some reasoning and explanation and suggestion to use absolute paths, since envs and symbols can cause difficulties.