### PR TITLE
build: include golang version change in release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ release: branch-check
 
 ## Change the golang version
 	sed 's/Version *=.*/Version = "$(version)"/' golang/internal/version/version.go > temp_file && mv temp_file golang/internal/version/version.go
+	git add golang/internal/version/version.go
 
 ## Change version of crux
 	jq '.version = "$(version)"' web/crux/package.json  > web/crux/package.json.tmp


### PR DESCRIPTION
The golang version.go change was left out.