### PR TITLE
build(ci): add missing go_push requirement

### DIFF
--- a/.github/workflows/product_builder.yaml
+++ b/.github/workflows/product_builder.yaml
@@ -578,7 +578,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ env.GOLANG_WORKING_DIRECTORY }}
-    needs: [gather_changes]
+    needs: [gather_changes, e2e]
     if: |
       always() &&
       (github.ref_name == 'develop' || github.ref_name == 'main' || github.ref_type == 'tag') &&


### PR DESCRIPTION
Golang images push job is now skipped because it is executed too early.