### PR TITLE
fix(dagent): discard image pull response if not read

### DIFF
--- a/golang/internal/helper/image/image.go
+++ b/golang/internal/helper/image/image.go
@@ -226,7 +226,8 @@ func CustomImagePull(ctx context.Context, imageName, encodedAuth string, forcePu
 	defer logdefer.LogDeferredErr(responseBody.Close, log.Warn(), "error in defer when closing pull response body:")
 
 	if displayFn == nil {
-		return nil
+		_, discardErr := io.Copy(io.Discard, responseBody)
+		return discardErr
 	}
 
 	return displayFn(fmt.Sprintf("Pull %v status:", imageName), responseBody)


### PR DESCRIPTION
Docker hangs until its response is read, dumping all the unread bytes solves the issue.