### PR TITLE
fix(agent): change agent start directive from CMD to ENTRYPOINT

### DIFF
--- a/golang/build/Dockerfile
+++ b/golang/build/Dockerfile
@@ -16,4 +16,4 @@ LABEL org.opencontainers.image.documentation="https://docs.dyrector.io"
 
 COPY ./out/$AGENT_BINARY-$TARGETOS-$TARGETARCH /agent
 
-CMD ["/agent"]
+ENTRYPOINT ["/agent"]


### PR DESCRIPTION
Our crane could not be installed because of this collision. Now the image can be run with parameters (again).