### PR TITLE
fix(dagent): correct entrypoint and cmd for init containers

### DIFF
--- a/golang/pkg/dagent/utils/init_container.go
+++ b/golang/pkg/dagent/utils/init_container.go
@@ -53,7 +53,8 @@ func spawnInitContainer(
 	resultCont, waitResult, err := builder.
 		WithClient(cli).
 		WithImage(config.Image).
-		WithCmd(config.Command).
+		WithEntrypoint(config.Command).
+		WithCmd(config.Args).
 		WithName(initContName).
 		WithEnv(MergeStringMapToUniqueSlice(initCont.EnvList, config.Envs)).
 		WithMountPoints(targetVolumes).


### PR DESCRIPTION
Entrypoint and command mapping into init containers was missing.