### PR TITLE
Refactor HTTP response status codes for request handlers

### DIFF
--- a/web/crux/src/app/audit/audit.http.controller.ts
+++ b/web/crux/src/app/audit/audit.http.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, Query } from '@nestjs/common'
+import { Controller, Get, HttpCode, HttpStatus, Query } from '@nestjs/common'
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Identity } from '@ory/kratos-client'
 import { IdentityFromRequest } from '../token/jwt-auth.guard'
@@ -11,7 +11,7 @@ export default class AuditController {
   constructor(private service: AuditService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Request must include `skip`, `take`, and dates of `from` and `to`. Response should include an array of `items`: `createdAt` date, `userId`, `email`, `serviceCall`, and `data`.',

--- a/web/crux/src/app/dashboard/dashboard.http.controller.ts
+++ b/web/crux/src/app/dashboard/dashboard.http.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode } from '@nestjs/common'
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common'
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Identity } from '@ory/kratos-client'
 import { IdentityFromRequest } from '../token/jwt-auth.guard'
@@ -11,7 +11,7 @@ export default class DashboardHttpController {
   constructor(private service: DashboardService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Response should include `users`, number of `auditLogEntries`, `projects`, `versions`, `deployments`, `failedDeployments`, details of `nodes`, `latestDeployments` and `auditLog` entries.',

--- a/web/crux/src/app/deploy/deploy.http.controller.ts
+++ b/web/crux/src/app/deploy/deploy.http.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   HttpCode,
+  HttpStatus,
   Param,
   Patch,
   Post,
@@ -82,7 +83,7 @@ export default class DeployHttpController {
   }
 
   @Get(ROUTE_DEPLOYMENT_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Get details of a certain deployment. Request must include `deploymentId`. Deployment details should include `id`, `prefix`, `environment`, `status`, `note`, `audit` log details, project `name`, `id`, `type`, version `name`, `type`, `id`, and node `name`, `id`, `type`.',
@@ -95,7 +96,7 @@ export default class DeployHttpController {
   }
 
   @Get(`${ROUTE_DEPLOYMENT_ID}/${ROUTE_INSTANCES}/${ROUTE_INSTANCE_ID}`)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Request must include `deploymentId` and `instanceId`, which refer to the ID of a deployment and the instance. Instances are the manifestation of an image in the deployment. Response should include `state`, `id`, `updatedAt`, and `image` details including `id`, `name`, `tag`, `order` and `config` variables.',
@@ -108,7 +109,7 @@ export default class DeployHttpController {
   }
 
   @Get(`${ROUTE_DEPLOYMENT_ID}/${ROUTE_INSTANCES}/${ROUTE_INSTANCE_ID}/secrets`)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Request must include `deploymentId` and `instanceId`, which refers to the ID of a deployment and the instance. Response should include container `prefix` and `name`, and `publicKey`, `keys`.',
@@ -124,7 +125,7 @@ export default class DeployHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     description:
       'Request must include `versionId`, `nodeId`, and `prefix`, which refers to the ID of a version, a node and the prefix of the deployment. Response should include deployment `id`, `prefix`, `status`, `note`, and `audit` log details, as well as project `type`, `id`, `name`, version `type`, `id`, `name`, and node `type`, `id`, `name`.',
@@ -148,7 +149,7 @@ export default class DeployHttpController {
   }
 
   @Patch(ROUTE_DEPLOYMENT_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `deploymentId`.',
     summary: 'Update deployment.',
@@ -165,7 +166,7 @@ export default class DeployHttpController {
   }
 
   @Patch(`${ROUTE_DEPLOYMENT_ID}/${ROUTE_INSTANCES}/${ROUTE_INSTANCE_ID}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       'Request must include `deploymentId` and `instanceId` and portion of the instance configuration as `config`. Response should include `config` variables in an array.',
@@ -184,7 +185,7 @@ export default class DeployHttpController {
   }
 
   @Delete(ROUTE_DEPLOYMENT_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `deploymentId`.',
     summary: 'Delete deployment.',
@@ -197,7 +198,7 @@ export default class DeployHttpController {
   }
 
   @Post(`${ROUTE_DEPLOYMENT_ID}/start`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `deploymentId`.',
     summary: 'Start the deployment process.',
@@ -215,7 +216,7 @@ export default class DeployHttpController {
   }
 
   @Post(`${ROUTE_DEPLOYMENT_ID}/copy`)
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     description:
       'Request must include `deploymentId`, which will be copied. The body must include the `nodeId`, `prefix` and optionally a `note`. Response should include deployment data: `id`, `prefix`, `status`, `note`, and miscellaneous details of `audit` log, `project`, `version`, and `node`.',
@@ -239,7 +240,7 @@ export default class DeployHttpController {
   }
 
   @Get(`${ROUTE_DEPLOYMENT_ID}/log`)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Request must include `deploymentId`. Response should include an `items` array with objects of `type`, `deploymentStatus`, `createdAt`, `log`, and `containerState` which consists of `state` and `instanceId`.',
@@ -255,7 +256,7 @@ export default class DeployHttpController {
   }
 
   @Put(`${ROUTE_DEPLOYMENT_ID}/${ROUTE_TOKEN}`)
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     description:
       'Request must include `deploymentId` in the url. In the body a `name` and optionally the expiration date as `expirationInDays`.',
@@ -278,7 +279,7 @@ export default class DeployHttpController {
   }
 
   @Delete(`${ROUTE_DEPLOYMENT_ID}/${ROUTE_TOKEN}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include the `deploymentId`.',
     summary: 'Delete deployment token.',

--- a/web/crux/src/app/image/image.http.controller.ts
+++ b/web/crux/src/app/image/image.http.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   HttpCode,
+  HttpStatus,
   Param,
   Patch,
   Post,
@@ -48,7 +49,7 @@ export default class ImageHttpController {
   constructor(private service: ImageService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Fetch details of images within a version. `ProjectId` refers to the project's ID, `versionId` refers to the version's ID. Both are required variables.</br></br>Details come in an array, including `name`, `id`, `tag`, `order`, and config details of the image.",
@@ -65,7 +66,7 @@ export default class ImageHttpController {
   }
 
   @Get(ROUTE_IMAGE_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Fetch details of an image within a version. `projectId` refers to the project's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required parameters.</br></br>Image details consists `name`, `id`, `tag`, `order`, and the config of the image.",
@@ -82,7 +83,7 @@ export default class ImageHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @CreatedWithLocation()
   @ApiOperation({
     description:
@@ -109,7 +110,7 @@ export default class ImageHttpController {
   }
 
   @Patch(ROUTE_IMAGE_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       "Modify the configuration variables of an image. `projectId` refers to the project's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required variables. `Tag` refers to the version of the image, `config` is an object of configuration variables.",
@@ -129,7 +130,7 @@ export default class ImageHttpController {
   }
 
   @Delete(ROUTE_IMAGE_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       "Delete an image. `projectId` refers to the project's ID, `versionId` refers to the version's ID, `imageId` refers to the image's ID. All are required variables.",
@@ -147,7 +148,7 @@ export default class ImageHttpController {
   }
 
   @Put('order')
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       "Edit image deployment order of a version. `projectId` refers to the project's ID, `versionId` refers to the version's ID. Both are required variables. Request should include the IDs of the images in an array.",

--- a/web/crux/src/app/metrics/metrics.controller.ts
+++ b/web/crux/src/app/metrics/metrics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, Response } from '@nestjs/common'
+import { Controller, Get, HttpCode, HttpStatus, Response } from '@nestjs/common'
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger'
 import { PrometheusController } from '@willsoto/nestjs-prometheus'
 import { AuditLogLevel } from 'src/decorators/audit-logger.decorator'
@@ -8,7 +8,7 @@ import { DisableAuth } from '../token/jwt-auth.guard'
 @ApiTags('metrics')
 export default class MetricsController extends PrometheusController {
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @AuditLogLevel('disabled')
   @ApiOkResponse({ type: String, description: 'Prometheus metrics' })
   @DisableAuth()

--- a/web/crux/src/app/node/node.global-container.http.controller.ts
+++ b/web/crux/src/app/node/node.global-container.http.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, HttpCode, Post, Query, UseGuards } from '@nestjs/common'
+import { Controller, Delete, Get, HttpCode, HttpStatus, Post, Query, UseGuards } from '@nestjs/common'
 import { ApiNoContentResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { from, mergeAll, Observable } from 'rxjs'
 import UuidParams from 'src/decorators/api-params.decorator'
@@ -23,7 +23,7 @@ export default class NodeGlobalContainerHttpController {
   constructor(private service: NodeService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Request must include `nodeId` and `prefix`. Response should include `id`, `command`, `createdAt`, `state`, `status`, `imageName`, `imageTag` and `ports` of images.',
@@ -35,7 +35,7 @@ export default class NodeGlobalContainerHttpController {
   }
 
   @Post(`${ROUTE_NAME}/start`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, and the `name` of the container.',
     summary: 'Start the specific container on a node.',
@@ -47,7 +47,7 @@ export default class NodeGlobalContainerHttpController {
   }
 
   @Post(`${ROUTE_NAME}/stop`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, and the `name` of the container.',
     summary: 'Stop the specific container on a node.',
@@ -59,7 +59,7 @@ export default class NodeGlobalContainerHttpController {
   }
 
   @Post(`${ROUTE_NAME}/restart`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, and the `name` of the container.',
     summary: 'Restart the specific container on a node.',
@@ -71,7 +71,7 @@ export default class NodeGlobalContainerHttpController {
   }
 
   @Delete(`${ROUTE_NAME}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, and the `name` of the container.',
     summary: 'Delete the specific container from a node.',

--- a/web/crux/src/app/node/node.http.controller.ts
+++ b/web/crux/src/app/node/node.http.controller.ts
@@ -1,4 +1,16 @@
-import { Body, Controller, Delete, Get, Header, HttpCode, Post, Put, Query, UseGuards } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Header,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common'
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -35,7 +47,7 @@ export default class NodeHttpController {
   constructor(private service: NodeService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Fetch data of deployment targets. Response should include an array with the node's `type`, `status`, `description`, `icon`, `address`, `connectedAt` date, `version`, `updating`, `id`, and `name`.",
@@ -51,7 +63,7 @@ export default class NodeHttpController {
   }
 
   @Get(ROUTE_NODE_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Fetch data of a specific node. Request must include `nodeId`. Response should include an array with the node's `type`, `status`, `description`, `icon`, `address`, `connectedAt` date, `version`, `updating`, `id`, `name`, `hasToken`, and agent installation details.",
@@ -64,7 +76,7 @@ export default class NodeHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     description:
       "Request must include the node's `name`. Response should include an array with the node's `type`, `status`, `description`, `icon`, `address`, `connectedAt` date, `version`, `updating`, `id`, and `name`.",
@@ -86,7 +98,7 @@ export default class NodeHttpController {
   }
 
   @Put(ROUTE_NODE_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: "Request must include the node's `name`, body can include `description` and `icon`.",
     summary: 'Update details of a node.',
@@ -102,7 +114,7 @@ export default class NodeHttpController {
   }
 
   @Delete(ROUTE_NODE_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`.',
     summary: 'Delete node.',
@@ -114,7 +126,7 @@ export default class NodeHttpController {
   }
 
   @Post(`${ROUTE_NODE_ID}/script`)
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     description: 'Request must include `nodeId`, `type` and `scriptType`.',
     summary: 'Create agent install script.',
@@ -130,7 +142,7 @@ export default class NodeHttpController {
   }
 
   @Delete(`${ROUTE_NODE_ID}/script`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`.',
     summary: 'Delete node set up install script.',
@@ -157,7 +169,7 @@ export default class NodeHttpController {
   }
 
   @Delete(`${ROUTE_NODE_ID}/token`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`.',
     summary: "Revoke the node's access token.",
@@ -169,7 +181,7 @@ export default class NodeHttpController {
   }
 
   @Post(`${ROUTE_NODE_ID}/update`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`.',
     summary: "Update node's data.",
@@ -181,7 +193,7 @@ export default class NodeHttpController {
   }
 
   @Get(`${ROUTE_NODE_ID}/audit`)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Request must include `skip`, `take`, and dates of `from` and `to`. Response should include an array of `items`: `createdAt` date, `event`, and `data`.',

--- a/web/crux/src/app/node/node.prefix-container.http.controller.ts
+++ b/web/crux/src/app/node/node.prefix-container.http.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, HttpCode, Post, UseGuards } from '@nestjs/common'
+import { Controller, Delete, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common'
 import { ApiNoContentResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Observable, from, mergeAll } from 'rxjs'
 import UuidParams from 'src/decorators/api-params.decorator'
@@ -23,7 +23,7 @@ export default class NodePrefixContainerHttpController {
   constructor(private service: NodeService) {}
 
   @Post(`${ROUTE_NAME}/start`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, `prefix`, and `name`.',
     summary: 'Start a container deployed with dyrector.io on a node.',
@@ -35,7 +35,7 @@ export default class NodePrefixContainerHttpController {
   }
 
   @Post(`${ROUTE_NAME}/stop`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, `prefix`, and `name`.',
     summary: 'Stop a container deployed with dyrector.io on a node.',
@@ -47,7 +47,7 @@ export default class NodePrefixContainerHttpController {
   }
 
   @Post(`${ROUTE_NAME}/restart`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, `prefix`, and `name`.',
     summary: 'Restart a container deployed with dyrector.io on a node.',
@@ -59,7 +59,7 @@ export default class NodePrefixContainerHttpController {
   }
 
   @Delete()
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, and `prefix`.',
     summary: 'Delete containers deployed with dyrector.io, with the specified prefix on a node.',
@@ -71,7 +71,7 @@ export default class NodePrefixContainerHttpController {
   }
 
   @Delete(`${ROUTE_NAME}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `nodeId`, `prefix`, and `name`.',
     summary: 'Delete a container deployed with dyrector.io, with the specified prefix and name on a node.',

--- a/web/crux/src/app/notification/notification.http.controller.ts
+++ b/web/crux/src/app/notification/notification.http.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards } from '@nestjs/common'
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Put, UseGuards } from '@nestjs/common'
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -33,7 +33,7 @@ export default class NotificationHttpController {
   constructor(private service: NotificationService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description: 'Response should include `type`, `id`, `name`, `url`, `active`, and `creatorName`.',
     summary: 'Retrieve notifications that belong to a team.',
@@ -44,7 +44,7 @@ export default class NotificationHttpController {
   }
 
   @Get(ROUTE_NOTIFICATION_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Request must include `notificationId` parameter. Response should include `type`, `enabledEvents`, `id`, `name`, `url`, `active`, and `creatorName`.',
@@ -56,7 +56,7 @@ export default class NotificationHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     description:
       'Request must include `type`, `enabledEvents`, `id`, `name`, `url`, and `active`. Response should list `type`, `enabledEvents`, `id`, `name`, `url`, `active`, and `creatorName`.',
@@ -78,7 +78,7 @@ export default class NotificationHttpController {
   }
 
   @Put(ROUTE_NOTIFICATION_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       'Request must include `notificationId`, `type`, `enabledEvents`, `id`, `name`, `url`, and `active`. Response should include `type`, `enabledEvents`, `id`, `name`, `url`, `active`, and `creatorName`.',
@@ -95,7 +95,7 @@ export default class NotificationHttpController {
   }
 
   @Delete(ROUTE_NOTIFICATION_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `notificationId`.',
     summary: 'Delete a notification.',
@@ -107,7 +107,7 @@ export default class NotificationHttpController {
   }
 
   @Post(`${ROUTE_NOTIFICATION_ID}/test`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `notificationId`.',
     summary: 'Send a test message.',

--- a/web/crux/src/app/project/project.http.controller.ts
+++ b/web/crux/src/app/project/project.http.controller.ts
@@ -1,4 +1,16 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards, UseInterceptors } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common'
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -29,7 +41,7 @@ export default class ProjectHttpController {
   constructor(private service: ProjectService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description: "Returns a list of a team's projects and their details.",
     summary: 'Fetch the projects list.',
@@ -45,7 +57,7 @@ export default class ProjectHttpController {
   }
 
   @Get(ROUTE_PROJECT_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Returns a project's details. The response should contain an array, consisting of the project's `name`, `id`, `type`, `description`, `deletability`, versions and version related data, including version `name` and `id`, `changelog`, increasibility.",
@@ -58,7 +70,7 @@ export default class ProjectHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     description:
       'Create a new project for a team. Newly created team has a `type` and a `name` as required variables, and optionally a `description` and a `changelog`.',
@@ -80,7 +92,7 @@ export default class ProjectHttpController {
   }
 
   @Put(ROUTE_PROJECT_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       'Updates a project. `projectId` is a required variable to identify which project is modified, `name`, `description` and `changelog` can be adjusted with this call.',
@@ -98,7 +110,7 @@ export default class ProjectHttpController {
   }
 
   @Delete(ROUTE_PROJECT_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Deletes a project with the specified `projectId`',
     summary: 'Delete a project.',
@@ -110,7 +122,7 @@ export default class ProjectHttpController {
   }
 
   @Post(`${ROUTE_PROJECT_ID}/convert`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Converts a project to versioned with the specified `projectId`',
     summary: 'Convert a project to versioned.',

--- a/web/crux/src/app/registry/registry.http.controller.ts
+++ b/web/crux/src/app/registry/registry.http.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, PipeTransform, Type, UseGuards } from '@nestjs/common'
+import { Controller, Get, HttpCode, HttpStatus, PipeTransform, Type, UseGuards } from '@nestjs/common'
 import { Delete, Post, Put } from '@nestjs/common/decorators/http/request-mapping.decorator'
 import { Body, Param } from '@nestjs/common/decorators/http/route-params.decorator'
 import {
@@ -33,7 +33,7 @@ export default class RegistryHttpController {
   constructor(private service: RegistryService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Lists every registries available in the active team. Response is an array including the `name`, `id`, `type`, `description`, and `icon` of the registry.</br></br>Registries are 3rd party registries where the container images are stored.',
@@ -45,7 +45,7 @@ export default class RegistryHttpController {
   }
 
   @Get(ROUTE_REGISTRY_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Lists the details of a registry. `registryId` refers to the registry's ID. Response is an array including the `name`, `id`, `type`, `description`, `imageNamePrefix`, `inUse`, `icon`, and audit log info of the registry.",
@@ -58,7 +58,7 @@ export default class RegistryHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @CreatedWithLocation()
   @ApiOperation({
     description:
@@ -85,7 +85,7 @@ export default class RegistryHttpController {
   }
 
   @Put(ROUTE_REGISTRY_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       "Modify the `name`, `type`, `description`, `details`, and `icon`. `registryId` refers to the registry's ID. `registryId`, `type`, `details`, and `name` are required.",
@@ -104,7 +104,7 @@ export default class RegistryHttpController {
   }
 
   @Delete(ROUTE_REGISTRY_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Deletes a registry with the specified `registryId`',
     summary: 'Delete a registry from dyrector.io.',

--- a/web/crux/src/app/storage/storage.http.controller.ts
+++ b/web/crux/src/app/storage/storage.http.controller.ts
@@ -1,4 +1,16 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards, UseInterceptors } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common'
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -29,7 +41,7 @@ export default class StorageHttpController {
   constructor(private service: StorageService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description: 'Response should include `description`, `icon`, `url`, `id`, and `name`.',
     summary: 'Fetch the list of storages.',
@@ -44,7 +56,7 @@ export default class StorageHttpController {
   }
 
   @Get('options')
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description: 'Response should include `id`, and `name`.',
     summary: 'Fetch the name and ID of available storage options.',
@@ -59,7 +71,7 @@ export default class StorageHttpController {
   }
 
   @Get(ROUTE_STORAGE_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'Get the details of a storage. Request must include `storageId`. Response should include description, icon, url, `id`, `name`, `accessKey`, `secretKey`, and `inUse`.',
@@ -72,7 +84,7 @@ export default class StorageHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     description:
       'Creates a new storage. Request must include `name`, and `url`. Request body may include `description`, `icon`, `accesKey`, and `secretKey`. Response should include `description`, `icon`, `url`, `id`, `name`, `accessKey`, `secretKey`, and `inUse`.',
@@ -94,7 +106,7 @@ export default class StorageHttpController {
   }
 
   @Put(ROUTE_STORAGE_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       'Updates a storage. Request must include `storageId`, `name`, and `url`. Request body may include `description`, `icon`, `accesKey`, and `secretKey`.',
@@ -111,7 +123,7 @@ export default class StorageHttpController {
   }
 
   @Delete(ROUTE_STORAGE_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Deletes a storage Request must include `storageId`.',
     summary: 'Delete a storage from dyrector.io.',

--- a/web/crux/src/app/team/team.http.controller.ts
+++ b/web/crux/src/app/team/team.http.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
   UseInterceptors,
   Request,
+  HttpStatus,
 } from '@nestjs/common'
 import {
   ApiBody,
@@ -51,7 +52,7 @@ export default class TeamHttpController {
   constructor(private service: TeamService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       'List of teams consist of `name`, `id`, and `statistics`, including number of `users`, `projects`, `nodes`, `versions`, and `deployments`.</br></br>Teams are the shared entity of multiple users. The purpose of teams is to separate users, nodes and projects based on their needs within an organization. Team owners can assign roles. More details about teams here.',
@@ -64,7 +65,7 @@ export default class TeamHttpController {
   }
 
   @Get(ROUTE_TEAM_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Get the details of a team. Request must include `teamId`, which is the ID of the team they'd like to get the data of. Data of teams consist of `name`, `id`, and `statistics`, including number of `users`, `projects`, `nodes`, `versions`, and `deployments`. Response should include user details, as well, including `name`, `id`, `role`, `status`, `email`, and `lastLogin`.",
@@ -77,7 +78,7 @@ export default class TeamHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @AuditLogLevel('disabled')
   @ApiOperation({
     description:
@@ -106,7 +107,7 @@ export default class TeamHttpController {
   }
 
   @Put(ROUTE_TEAM_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBody({ type: UpdateTeamDto })
   @ApiOperation({
     description: 'Request must include `teamId` and `name`. Admin access required for a successful request.',
@@ -124,7 +125,7 @@ export default class TeamHttpController {
   }
 
   @Delete(ROUTE_TEAM_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @AuditLogLevel('disabled')
   @ApiOperation({
     description: 'Request must include `teamId`. Owner access required for successful request.',
@@ -141,7 +142,7 @@ export default class TeamHttpController {
   // Users endpoints
 
   @Post(`${ROUTE_TEAM_ID}/${ROUTE_USERS}`)
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @CreatedWithLocation()
   @ApiOperation({
     description:
@@ -171,7 +172,7 @@ export default class TeamHttpController {
   }
 
   @Put(`${ROUTE_TEAM_ID}/${ROUTE_USERS}/${ROUTE_USER_ID}/role`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBody({ type: UpdateUserRoleDto })
   @ApiOperation({
     description:
@@ -192,7 +193,7 @@ export default class TeamHttpController {
   }
 
   @Delete(`${ROUTE_TEAM_ID}/${ROUTE_USERS}/${ROUTE_USER_ID}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @TeamRoleRequired('admin')
   @ApiOperation({
     description:
@@ -207,7 +208,7 @@ export default class TeamHttpController {
   }
 
   @Post(`${ROUTE_TEAM_ID}/${ROUTE_USERS}/${ROUTE_USER_ID}/reinvite`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @UseInterceptors(TeamReinviteUserValidationInterceptor)
   @ApiOperation({
     description:

--- a/web/crux/src/app/team/user.http.controller.ts
+++ b/web/crux/src/app/team/user.http.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, HttpCode, Param, Post, Put } from '@nestjs/common'
+import { Body, Controller, Delete, HttpCode, HttpStatus, Param, Post, Put } from '@nestjs/common'
 import { ApiBody, ApiNoContentResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Identity } from '@ory/kratos-client'
 import UuidParams from 'src/decorators/api-params.decorator'
@@ -24,7 +24,7 @@ export default class UserHttpController {
   constructor(private service: TeamService) {}
 
   @Post()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @AuditLogLevel('disabled')
   @ApiOperation({
     description: 'Response includes the `user`, `activeTeamId`, `teams`, and `invitations`.',
@@ -36,7 +36,7 @@ export default class UserHttpController {
   }
 
   @Post(ROUTE_ACTIVE_TEAM)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `teamID`.',
     summary: 'Sets the active team.',
@@ -48,7 +48,7 @@ export default class UserHttpController {
   }
 
   @Post(`${ROUTE_INVITATIONS}/${ROUTE_TEAM_ID}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `teamID`.',
     summary: 'Accept invitation to a team.',
@@ -60,7 +60,7 @@ export default class UserHttpController {
   }
 
   @Delete(`${ROUTE_INVITATIONS}/${ROUTE_TEAM_ID}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `teamID`.',
     summary: 'Decline invitation to a team.',
@@ -72,7 +72,7 @@ export default class UserHttpController {
   }
 
   @Put(`${ROUTE_PREFERENCES}/${ROUTE_ONBOARDING}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Enable onboarding tips.',
     summary: 'Sets the onboarding tips to visible for the user.',
@@ -83,7 +83,7 @@ export default class UserHttpController {
   }
 
   @Delete(`${ROUTE_PREFERENCES}/${ROUTE_ONBOARDING}`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Disable onboarding tips.',
     summary: 'Sets the onboarding tips to hidden for the user.',

--- a/web/crux/src/app/template/template.http.controller.ts
+++ b/web/crux/src/app/template/template.http.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Header, HttpCode, Param, Post, Response } from '@nestjs/common'
+import { Body, Controller, Get, Header, HttpCode, HttpStatus, Param, Post, Response } from '@nestjs/common'
 import { ApiBody, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Identity } from '@ory/kratos-client'
 import { Response as ExpressResponse } from 'express'
@@ -21,7 +21,7 @@ export default class TemplateHttpController {
   constructor(private service: TemplateService, private templateFileService: TemplateFileService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description: 'Response should include `id`, `name`, `description` and `technologies` of templates.',
     summary: 'Return list of templates on the platform.',
@@ -32,7 +32,7 @@ export default class TemplateHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @CreatedWithLocation()
   @ApiOperation({
     description:
@@ -54,7 +54,7 @@ export default class TemplateHttpController {
   }
 
   @Get(`${ROUTE_TEMPLATE_ID}/image`)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description: 'Request must include `templateId`.',
     summary: 'Retrieves the picture of the template',

--- a/web/crux/src/app/token/token.http.controller.ts
+++ b/web/crux/src/app/token/token.http.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, UseGuards } from '@nestjs/common'
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, UseGuards } from '@nestjs/common'
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -30,7 +30,7 @@ export default class TokenHttpController {
   constructor(private service: TokenService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description: "Access token's support is to provide secure access to the HTTP api without a cookie.",
     summary: 'List of tokens.',
@@ -45,7 +45,7 @@ export default class TokenHttpController {
   }
 
   @Get(ROUTE_TOKEN_ID)
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Access token's details are `name`, `id`, and the time of creation and expiration. Request must include `tokenId`.",
@@ -58,7 +58,7 @@ export default class TokenHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @CreatedWithLocation()
   @ApiOperation({
     description: 'Request must include `name` and `expirationInDays`.',
@@ -82,7 +82,7 @@ export default class TokenHttpController {
   }
 
   @Delete(ROUTE_TOKEN_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description: 'Request must include `tokenId`.',
     summary: 'Delete an access token.',

--- a/web/crux/src/app/version/version.http.controller.ts
+++ b/web/crux/src/app/version/version.http.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   HttpCode,
+  HttpStatus,
   Param,
   Post,
   Put,
@@ -55,7 +56,7 @@ export default class VersionHttpController {
   constructor(private service: VersionService) {}
 
   @Get()
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
     description:
       "Returns an array containing the every version that belong to a project. `projectId` refers to the project's ID. Details include the version's `name`, `id`, `type`, `audit` log details, `changelog`, and increasibility.",
@@ -88,7 +89,7 @@ export default class VersionHttpController {
   }
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @CreatedWithLocation()
   @UseInterceptors(VersionCreateValidationInterceptor)
   @ApiOperation({
@@ -113,7 +114,7 @@ export default class VersionHttpController {
   }
 
   @Put(ROUTE_VERSION_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       "Updates a version's `name` and `changelog`. `projectId` refers to the project's ID, `versionId` refers to the version's ID. Both are required variables.",
@@ -133,7 +134,7 @@ export default class VersionHttpController {
   }
 
   @Delete(ROUTE_VERSION_ID)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       "This call deletes a version. `projectId` refers to the project's ID, `versionId` refers to the version's ID. Both are required variables.",
@@ -147,7 +148,7 @@ export default class VersionHttpController {
   }
 
   @Put(`${ROUTE_VERSION_ID}/default`)
-  @HttpCode(204)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     description:
       "This call turns a version into the default one, resulting other versions within this project later inherit images, deployments and their configurations from it. `projectId` refers to the project's ID, `versionId` refers to the version's ID. Both are required variables.",
@@ -163,7 +164,7 @@ export default class VersionHttpController {
   }
 
   @Post(`${ROUTE_VERSION_ID}/increase`)
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @CreatedWithLocation()
   @ApiOperation({
     description:


### PR DESCRIPTION
We use the built-in Nest.js `HttpStatus` enums as `@HttpCode` parameters instead of magic numbers.