### PR TITLE
cicd: add deploy_external workflow for external webhooks & sundyo

### DIFF
--- a/.github/workflows/deploy_external.yaml
+++ b/.github/workflows/deploy_external.yaml
@@ -1,0 +1,23 @@
+# workflow containing webhooks that are external to us
+name: deploy_external
+on:
+  workflow_run:
+    workflows:
+      - "product_builder"
+    branches:
+      - "develop"
+    types:
+      - completed
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+jobs:
+  execute-webhook:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Webhook
+        run: |
+          curl -X POST -H 'Authorization: Bearer ${{SUN_DYO_WEBHOOK_TOKEN}}' https://app.dyrectorio.com/api/deployments/8322f763-e611-40c7-a29b-bb21f2fd4822/start
+

--- a/.github/workflows/deploy_external.yaml
+++ b/.github/workflows/deploy_external.yaml
@@ -17,7 +17,6 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-22.04
     steps:
-      - name: Webhook
+      - name: Execute dedicated Sunilium instance webhook
         run: |
           curl -X POST -H 'Authorization: Bearer ${{SUN_DYO_WEBHOOK_TOKEN}}' https://app.dyrectorio.com/api/deployments/8322f763-e611-40c7-a29b-bb21f2fd4822/start
-


### PR DESCRIPTION
This is an attempt of dogfooding, where we use github actions to trigger our CD for rolling version, where we update a remotely deployed dyrector.io :pizza: 