### PR TITLE
fix(crux-ui): add view buttons to deployment list rows

### DIFF
--- a/web/crux-ui/src/components/projects/project-view-list.tsx
+++ b/web/crux-ui/src/components/projects/project-view-list.tsx
@@ -7,6 +7,7 @@ import { auditToLocaleDate } from '@app/utils'
 import clsx from 'clsx'
 import useTranslation from 'next-translate/useTranslation'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import ProjectTypeTag from './project-type-tag'
 
 export interface ProjectViewListProps {
@@ -15,8 +16,8 @@ export interface ProjectViewListProps {
 
 const ProjectViewList = (props: ProjectViewListProps) => {
   const { projects } = props
-
   const { t } = useTranslation('projects')
+  const router = useRouter()
 
   const columnWidths = ['w-6/12', 'w-1/12', 'w-2/12', 'w-2/12', 'w-1/12']
   const headers = ['name', 'versions', 'common:updatedAt', 'type', 'common:actions']
@@ -35,6 +36,14 @@ const ProjectViewList = (props: ProjectViewListProps) => {
     clsx('pr-6 text-center', defaultItemClass),
   ]
 
+  const onCellClick = async (data: Project, row: number, col: number) => {
+    if (col >= headers.length - 1) {
+      return
+    }
+
+    await router.push(projectUrl(data.id))
+  }
+
   const itemTemplate = (item: Project) => [
     <a>{item.name}</a>,
     <a>{item.versionCount}</a>,
@@ -48,6 +57,7 @@ const ProjectViewList = (props: ProjectViewListProps) => {
   ]
 
   return (
+    // TODO: wire in the implemented onCellClick() to the DyoList
     <DyoCard className="relative mt-4">
       <DyoList
         headers={[...headers.map(h => t(h)), '']}
@@ -57,6 +67,7 @@ const ProjectViewList = (props: ProjectViewListProps) => {
         data={projects}
         noSeparator
         itemBuilder={itemTemplate}
+        cellClick={onCellClick}
       />
     </DyoCard>
   )

--- a/web/crux-ui/src/components/projects/project-view-list.tsx
+++ b/web/crux-ui/src/components/projects/project-view-list.tsx
@@ -57,7 +57,6 @@ const ProjectViewList = (props: ProjectViewListProps) => {
   ]
 
   return (
-    // TODO: wire in the implemented onCellClick() to the DyoList
     <DyoCard className="relative mt-4">
       <DyoList
         headers={[...headers.map(h => t(h)), '']}

--- a/web/crux-ui/src/components/projects/versions/version-deployments-section.tsx
+++ b/web/crux-ui/src/components/projects/versions/version-deployments-section.tsx
@@ -214,6 +214,14 @@ const VersionDeploymentsSection = (props: VersionDeploymentsSectionProps) => {
     clsx('pr-6 text-center', defaultItemClass),
   ]
 
+  const onCellClick = async (data: DeploymentByVersion, row: number, col: number) => {
+    if (col >= headers.length - 1) {
+      return
+    }
+
+    await router.push(deploymentUrl(data.id))
+  }
+
   const itemTemplate = (item: DeploymentByVersion) => {
     const deployable = deploymentIsDeployable(item.status, version.type)
 
@@ -313,6 +321,7 @@ const VersionDeploymentsSection = (props: VersionDeploymentsSectionProps) => {
               headerBuilder={sortHeaderBuilder<DeploymentByVersion, DeploymentSorting>(sorting, sortHeaders, text =>
                 t(text),
               )}
+              cellClick={onCellClick}
             />
           </DyoCard>
         </>

--- a/web/crux-ui/src/pages/deployments.tsx
+++ b/web/crux-ui/src/pages/deployments.tsx
@@ -27,6 +27,7 @@ import { getCruxFromContext } from '@server/crux-api'
 import clsx from 'clsx'
 import { NextPageContext } from 'next'
 import useTranslation from 'next-translate/useTranslation'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
@@ -137,6 +138,10 @@ const DeploymentsPage = (props: DeploymentsPageProps) => {
     <span suppressHydrationWarning>{auditToLocaleDate(item.audit)}</span>,
     <DeploymentStatusTag status={item.status} className="w-fit mx-auto" />,
     <>
+      <Link href={deploymentUrl(item.id)} passHref>
+        <DyoIcon src="/eye.svg" alt={t('common:view')} size="md" />
+      </Link>
+
       <div className="inline-block mr-2">
         <DyoIcon
           src="/note.svg"

--- a/web/crux/src/app/deploy/deploy.dto.ts
+++ b/web/crux/src/app/deploy/deploy.dto.ts
@@ -1,7 +1,18 @@
 import { ApiProperty, OmitType, PartialType } from '@nestjs/swagger'
 import { Deployment, DeploymentToken, Instance, InstanceContainerConfig, Node, Project, Version } from '@prisma/client'
 import { Type } from 'class-transformer'
-import { IsDate, IsIn, IsInt, IsJWT, IsOptional, IsString, IsUUID, Min, ValidateNested } from 'class-validator'
+import {
+  IsDate,
+  IsIn,
+  IsInt,
+  IsJWT,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+  MinLength,
+  ValidateNested,
+} from 'class-validator'
 import { CONTAINER_STATE_VALUES, ContainerState } from 'src/domain/container'
 import { PaginatedList, PaginationQuery } from 'src/shared/dtos/paginating'
 import { BasicProperties } from '../../shared/dtos/shared.dto'
@@ -106,7 +117,7 @@ export class DeploymentTokenDto {
 
 export class CreateDeploymentTokenDto {
   @IsString()
-  @Min(3)
+  @MinLength(3)
   name: string
 
   @IsInt()


### PR DESCRIPTION
- Fixed view buttons were missing from the deployments list rows.
- Fixed project list rows were not clickable to view them (similarly to the deployment list rows).
- Fixed version deployment list rows were not clickable to view them (similarly to the deployment list rows).
