### PR TITLE
fix(crux-ui): change confirm button color

### DIFF
--- a/web/crux-ui/src/components/team/user-role-action.tsx
+++ b/web/crux-ui/src/components/team/user-role-action.tsx
@@ -85,7 +85,7 @@ const UserRoleAction = (props: UserRoleActionProps) => {
         config={roleUpdateModalConfig}
         title={t('common:areYouSure')}
         className="w-1/4"
-        confirmColor="bg-error-red"
+        confirmColor="bg-warning-orange"
       />
     </div>
   )

--- a/web/crux-ui/src/pages/projects/[projectId].tsx
+++ b/web/crux-ui/src/pages/projects/[projectId].tsx
@@ -237,7 +237,7 @@ const ProjectDetailsPage = (props: ProjectDetailsPageProps) => {
           title={t('convertProjectToVersioned', { name: project.name })}
           description={t('areYouSureWantToConvert')}
           className="w-1/4"
-          confirmColor="bg-error-red"
+          confirmColor="bg-warning-orange"
         />
       )}
     </Layout>


### PR DESCRIPTION
Change the color of the confirm button to warning instead of error.