### PR TITLE
fix(dagent): remove host Rule if no root domain is given

### DIFF
--- a/golang/internal/helper/string.go
+++ b/golang/internal/helper/string.go
@@ -1,0 +1,11 @@
+package helper
+
+func FirstN(str string, n int) string {
+	if len(str) < n {
+		return str
+	}
+	if n < 1 {
+		return ""
+	}
+	return str[0:n]
+}

--- a/golang/internal/helper/string_test.go
+++ b/golang/internal/helper/string_test.go
@@ -1,0 +1,24 @@
+//go:build unit
+// +build unit
+
+package helper_test
+
+import (
+	"testing"
+
+	"github.com/dyrector-io/dyrectorio/golang/internal/helper"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFirstCharacters(t *testing.T) {
+	assert.Equal(t, "858ee29b2824", helper.FirstN("858ee29b28249ea83dd9430c15b4517224e46cb88aaf50ce90913be5a895500e", 12))
+}
+
+func TestFirstCharactersSmallerInputThanN(t *testing.T) {
+	assert.Equal(t, "858ee", helper.FirstN("858ee", 12))
+}
+
+func TestFirstCharactersNegativeN(t *testing.T) {
+	assert.Equal(t, "", helper.FirstN("858ee", -10))
+}

--- a/golang/pkg/dagent/utils/docker.go
+++ b/golang/pkg/dagent/utils/docker.go
@@ -159,16 +159,6 @@ func logDeployInfo(
 		fmt.Sprintf("Using image: %s", expandedImageName),
 	)
 
-	labels, _ := GetImageLabels(expandedImageName)
-	if len(labels) > 0 {
-		labelsLog := []string{"Image labels:"}
-		for key, label := range labels {
-			labelsLog = append(labelsLog, fmt.Sprintf("%s: %s", key, label))
-		}
-		dog.Write(labelsLog...)
-	}
-
-	dog.Write("Start container request for: " + containerName)
 	if deployImageRequest.ContainerConfig.RestartPolicy != "" {
 		dog.Write(fmt.Sprintf("Using restart policy: %v", deployImageRequest.ContainerConfig.RestartPolicy))
 	}
@@ -529,8 +519,11 @@ func setImageLabels(expandedImageName string,
 
 	// add traefik related labels to the container if expose true
 	if deployImageRequest.ContainerConfig.Expose {
-		traefikLabels := GetTraefikLabels(&deployImageRequest.InstanceConfig,
+		traefikLabels, labelErr := GetTraefikLabels(&deployImageRequest.InstanceConfig,
 			&deployImageRequest.ContainerConfig, cfg)
+		if labelErr != nil {
+			return nil, labelErr
+		}
 		maps.Copy(labels, traefikLabels)
 	}
 


### PR DESCRIPTION
In dagent if no enough config provided: no domain, nor env variable the Host rule is omitted.
If Expose is set but no prefix or domain is provided, it error is thrown by the deployment.