### PR TITLE
refactor(crane): use deployment, add RBAC changes

### DIFF
--- a/golang/internal/health/server.go
+++ b/golang/internal/health/server.go
@@ -61,6 +61,11 @@ func Serve(ctx context.Context) error {
 		log.Error().Str("file", socketPath).Err(err).Msg("Failed to check socket file")
 	}
 
+	err = os.MkdirAll(getSocketDir(), dirPerm)
+	if err != nil {
+		return err
+	}
+
 	socket, err := net.Listen(socketType, socketPath)
 	if err != nil {
 		return err

--- a/golang/internal/health/types.go
+++ b/golang/internal/health/types.go
@@ -5,12 +5,19 @@ import (
 	"path"
 )
 
-const socketType = "unix"
+const (
+	socketType = "unix"
+	dirPerm    = 0o755
+)
 
 type Status struct {
 	Connected bool `json:"connected" binding:"required"`
 }
 
+func getSocketDir() string {
+	return path.Join(os.TempDir(), "dyrectorio")
+}
+
 func getSocketPath() string {
-	return path.Join(os.TempDir(), "dyrectorio", "agenthealth.sock")
+	return path.Join(getSocketDir(), "agenthealth.sock")
 }

--- a/golang/pkg/crane/config/config.go
+++ b/golang/pkg/crane/config/config.go
@@ -16,6 +16,8 @@ type Configuration struct {
 	KeyIssuer           string        `yaml:"keyIssuer"             env:"KEY_ISSUER"                env-default:"co.dyrector.io/issuer"`
 	KubeConfig          string        `yaml:"kubeConfig"            env:"KUBECONFIG"                env-default:""`
 	TestTimeoutDuration time.Duration `yaml:"testTimeout"           env:"TEST_TIMEOUT"              env-default:"15s"`
+	OwnDeployment       string        `yaml:"ownDeployment"         env:"CRANE_DEPLOYMENT_NAME"`
+	OwnNamespace        string        `yaml:"ownNamescae"           env:"CRANE_DEPLOYMENT_NAMESPACE"`
 	// for injecting SecretPrivateKey
 	SecretName string `yaml:"secretName"  env:"SECRET_NAME"         env-default:"dyrectorio-secret"`
 	Namespace  string `yaml:"namespace"   env:"SECRET_NAMESPACE"    env-default:"dyrectorio"`

--- a/golang/pkg/crane/config/config.go
+++ b/golang/pkg/crane/config/config.go
@@ -17,7 +17,7 @@ type Configuration struct {
 	KubeConfig          string        `yaml:"kubeConfig"            env:"KUBECONFIG"                env-default:""`
 	TestTimeoutDuration time.Duration `yaml:"testTimeout"           env:"TEST_TIMEOUT"              env-default:"15s"`
 	OwnDeployment       string        `yaml:"ownDeployment"         env:"CRANE_DEPLOYMENT_NAME"`
-	OwnNamespace        string        `yaml:"ownNamescae"           env:"CRANE_DEPLOYMENT_NAMESPACE"`
+	OwnNamespace        string        `yaml:"ownNamespace"           env:"CRANE_DEPLOYMENT_NAMESPACE"`
 	// for injecting SecretPrivateKey
 	SecretName string `yaml:"secretName"  env:"SECRET_NAME"         env-default:"dyrectorio-secret"`
 	Namespace  string `yaml:"namespace"   env:"SECRET_NAMESPACE"    env-default:"dyrectorio"`

--- a/web/crux/assets/install-script/install-k8s.sh.hbr
+++ b/web/crux/assets/install-script/install-k8s.sh.hbr
@@ -4,9 +4,6 @@ set -e
 # migrating away from deployments because of the limited restartPolicy
 kubectl delete -n dyrectorio deployment dyrectorio-k8s-agent || true
 
-# restart command:
-# kubectl get pod dyrectorio-k8s-agent -o yaml | kubectl replace --force -f -
-
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Namespace
@@ -37,7 +34,6 @@ rules:
   apiGroups:
   - ""
   resources:
-  - namespaces
   - pvc
   verbs:
   - get
@@ -64,6 +60,8 @@ rules:
   - secrets
   - servicemonitors
   - configmaps
+  - events
+  - namespaces
   verbs:
   - create
   - delete
@@ -110,44 +108,57 @@ subjects:
   name: default
   namespace: dyrectorio
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: dyrectorio-k8s-agent
   namespace: dyrectorio
   labels:
     app: dyrectorio-k8s-agent
 spec:
-  initContainers:
-  - name: crane-init
-    image: ghcr.io/dyrector-io/dyrectorio/agent/crane:{{agentImageTag}}
-    args:
-      - init
-    imagePullPolicy: Always
-    resources:
-      requests:
-        memory: 128Mi
-      limits:
-        cpu: "1"
-        memory: 256Mi
-    envFrom:
-      - configMapRef:
-          name: crane-config
-  containers:
-  - name: crane
-    image: ghcr.io/dyrector-io/dyrectorio/agent/crane:{{agentImageTag}}
-    imagePullPolicy: Always
-    resources:
-      requests:
-        memory: 128Mi
-        cpu: 84m
-      limits:
-        cpu: "1"
-        memory: 256Mi
-    envFrom:
-      - configMapRef:
-          name: crane-config
-      - secretRef:
-          name: dyrectorio-secret
-  restartPolicy: OnFailure
+  selector:
+    matchLabels:
+      app: dyrectorio-k8s-agent
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: dyrectorio-k8s-agent
+    spec:
+      initContainers:
+      - name: crane-init
+        image: ghcr.io/dyrector-io/dyrectorio/agent/crane:{{agentImageTag}}
+        args:
+        - init
+        imagePullPolicy: Always
+        resources:
+          requests:
+              memory: 128Mi
+          limits:
+              cpu: "1"
+              memory: 256Mi
+        envFrom:
+        - configMapRef:
+            name: crane-config
+        env:
+        - name: CRANE_DEPLOYMENT_NAME
+          valueFrom: {fieldRef: {fieldPath: metadata.name}}
+        - name: CRANE_DEPLOYMENT_NAMESPACE
+          valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+      containers:
+      - name: crane
+        image: ghcr.io/dyrector-io/dyrectorio/agent/crane:{{agentImageTag}}
+        imagePullPolicy: Always
+        resources:
+          requests:
+              memory: 128Mi
+              cpu: 84m
+          limits:
+              cpu: "1"
+              memory: 256Mi
+        envFrom:
+        - configMapRef:
+            name: crane-config
+        - secretRef:
+            name: dyrectorio-secret
 EOF


### PR DESCRIPTION
Launching crane as a pod proved to be wrong, reverting to deployment.