### PR TITLE
refactor(web): optimize ws client routing

### DIFF
--- a/web/crux-ui/src/websockets/websocket-client-route.ts
+++ b/web/crux-ui/src/websockets/websocket-client-route.ts
@@ -121,12 +121,6 @@ class WebSocketClientRoute {
   }
 
   onMessage(message: WsMessage) {
-    const messageRoutePath = WebSocketClientRoute.routePathOf(message)
-    if (this.path !== messageRoutePath) {
-      // TODO(@m8vago): create a map in the websocket-client for the route prefixes and use that for routing
-      return
-    }
-
     // strip the basepath
     message.type = message.type.substring(this.path.length + 1)
 
@@ -166,7 +160,7 @@ class WebSocketClientRoute {
     }
   }
 
-  private static routePathOf(message: WsMessage): string | null {
+  static routePathOf(message: WsMessage): string | null {
     const index = message.type.lastIndexOf('/')
     if (index < 0) {
       return null

--- a/web/crux-ui/src/websockets/websocket-client.ts
+++ b/web/crux-ui/src/websockets/websocket-client.ts
@@ -237,7 +237,13 @@ class WebSocketClient {
           return
         }
 
-        this.routes.forEach(r => r.onMessage(message))
+        const path = WebSocketClientRoute.routePathOf(message)
+        const route = this.routes.get(path)
+        if (!route) {
+          this.logger.error(`Route not found: ${path}`)
+        }
+
+        route.onMessage(message)
       }
 
       this.clearSocket()

--- a/web/crux/src/app/deploy/deploy.http.controller.ts
+++ b/web/crux/src/app/deploy/deploy.http.controller.ts
@@ -195,8 +195,9 @@ export default class DeployHttpController {
     @TeamSlug() _: string,
     @DeploymentId() deploymentId: string,
     @Body() request: PatchDeploymentDto,
+    @IdentityFromRequest() identity: Identity,
   ): Promise<void> {
-    await this.service.patchDeployment(deploymentId, request)
+    await this.service.patchDeployment(deploymentId, request, identity)
   }
 
   @Patch(`${ROUTE_DEPLOYMENT_ID}/${ROUTE_INSTANCES}/${ROUTE_INSTANCE_ID}`)

--- a/web/crux/src/app/deploy/deploy.service.ts
+++ b/web/crux/src/app/deploy/deploy.service.ts
@@ -278,7 +278,8 @@ export default class DeployService {
     return this.mapper.toDto(deployment)
   }
 
-  async patchDeployment(deploymentId: string, req: PatchDeploymentDto): Promise<void> {
+  async patchDeployment(deploymentId: string, req: PatchDeploymentDto, identity: Identity): Promise<void> {
+    console.log('patchdeployment')
     if (req.configBundleIds) {
       const connections = await this.prisma.deployment.findFirst({
         where: {
@@ -313,6 +314,22 @@ export default class DeployService {
         })
       }
     }
+
+    console.log('updaaate', req)
+    await this.prisma.deployment.update({
+      where: {
+        id: deploymentId,
+      },
+      data: {
+        note: req.note ?? undefined,
+        prefix: req.prefix ?? undefined,
+        protected: req.protected ?? undefined,
+        environment: req.environment
+          ? req.environment.map(it => this.containerMapper.uniqueKeyValueDtoToDb(it))
+          : undefined,
+        updatedBy: identity.id,
+      },
+    })
   }
 
   async patchInstance(

--- a/web/crux/src/app/deploy/deploy.service.ts
+++ b/web/crux/src/app/deploy/deploy.service.ts
@@ -279,7 +279,6 @@ export default class DeployService {
   }
 
   async patchDeployment(deploymentId: string, req: PatchDeploymentDto, identity: Identity): Promise<void> {
-    console.log('patchdeployment')
     if (req.configBundleIds) {
       const connections = await this.prisma.deployment.findFirst({
         where: {
@@ -315,7 +314,6 @@ export default class DeployService {
       }
     }
 
-    console.log('updaaate', req)
     await this.prisma.deployment.update({
       where: {
         id: deploymentId,

--- a/web/crux/src/app/deploy/deploy.ws.gateway.ts
+++ b/web/crux/src/app/deploy/deploy.ws.gateway.ts
@@ -223,13 +223,14 @@ export default class DeployWebSocketGateway {
     @SocketMessage() message: PatchDeploymentEnvMessage,
     @SocketClient() client: WsClient,
     @SocketSubscription() subscription: WsSubscription,
+    @IdentityFromSocket() identity: Identity,
   ): Promise<WsMessage<null>> {
     const cruxReq: PatchDeploymentDto = {
       environment: message.environment,
       configBundleIds: message.configBundleIds,
     }
 
-    await this.service.patchDeployment(deploymentId, cruxReq)
+    await this.service.patchDeployment(deploymentId, cruxReq, identity)
 
     const configBundleEnvironment = await this.service.getConfigBundleEnvironmentsById(deploymentId)
 


### PR DESCRIPTION
- Use the `routes` map on client side websocket to route messages.
- Fix deployment environment editing