### PR TITLE
fix(agent): crashing on install and connection token mismatch

### DIFF
--- a/golang/internal/config/secret.go
+++ b/golang/internal/config/secret.go
@@ -119,7 +119,7 @@ func (c *CommonConfiguration) InjectGrpcToken(secrets SecretStore) error {
 		// set the token from the environment as a fallback
 		c.JwtToken, err = ValidateJwtAndCheckNonceBlacklist(secrets, c.GrpcToken)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to validate the grpc token supplied in the environment variables.")
+			log.Error().Err(err).Msg("Failed to validate the gRPC token supplied in the environment variables.")
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue, where reinstalling an agent for a different backend (issuer) caused a crash. Now we prefer the environment supplied grpc token over the saved one on issuer mismatch.