### PR TITLE
fix: kratos user list pagination

### DIFF
--- a/web/crux/src/app/audit/audit.mapper.ts
+++ b/web/crux/src/app/audit/audit.mapper.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { Identity } from '@ory/kratos-client'
 import { AuditLog, AuditLogActorTypeEnum, DeploymentToken } from '@prisma/client'
 import { emailOfIdentity, nameOfIdentity } from 'src/domain/identity'
-import { AuditDto, AuditLogActorTypeDto, AuditLogDto } from './audit.dto'
+import { AuditDto, AuditLogActorTypeDto, AuditLogDto, AuditLogUserDto } from './audit.dto'
 
 @Injectable()
 export default class AuditMapper {
@@ -36,6 +36,14 @@ export default class AuditMapper {
 
     if (it.actorType === 'user') {
       const identity = identities.get(it.userId)
+      if (!identity) {
+        return {
+          ...base,
+          name: AuditMapper.UNKNOWN_USER_NAME,
+          user: AuditMapper.UNKNOWN_USER,
+        }
+      }
+
       return {
         ...base,
         name: nameOfIdentity(identity),
@@ -50,6 +58,13 @@ export default class AuditMapper {
       ...base,
       name: it.deploymentToken.name,
     }
+  }
+
+  private static readonly UNKNOWN_USER_NAME = 'Unknown User'
+
+  private static readonly UNKNOWN_USER: AuditLogUserDto = {
+    email: '',
+    id: '',
   }
 }
 

--- a/web/crux/src/app/audit/audit.service.ts
+++ b/web/crux/src/app/audit/audit.service.ts
@@ -63,14 +63,12 @@ export default class AuditService {
       return {}
     }
 
-    const userIds = await this.kratos.getIdentityIdsByEmail(filter)
+    const user = await this.kratos.getIdentityByEmail(filter)
 
     return {
       OR: [
         {
-          userId: {
-            in: userIds,
-          },
+          userId: user.id,
         },
         {
           event: {

--- a/web/crux/src/services/kratos.service.ts
+++ b/web/crux/src/services/kratos.service.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto'
 import { setDefaultResultOrder } from 'dns'
 import http from 'http'
 import { IdentityTraits, KRATOS_IDENTITY_SCHEMA, KratosInvitation } from 'src/domain/identity'
-import { PRODUCTION } from 'src/shared/const'
+import { KRATOS_LIST_PAGE_SIZE, PRODUCTION } from 'src/shared/const'
 
 type KratosListHeaders = {
   link?: string
@@ -51,7 +51,7 @@ export default class KratosService {
       if (!identities) {
         // eslint-disable-next-line no-await-in-loop
         identities = await this.identity.listIdentities({
-          perPage: 128,
+          perPage: KRATOS_LIST_PAGE_SIZE,
         })
       } else {
         const headers = identities.headers as KratosListHeaders

--- a/web/crux/src/services/kratos.service.ts
+++ b/web/crux/src/services/kratos.service.ts
@@ -1,11 +1,18 @@
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { Configuration, FrontendApi, Identity, IdentityApi, Session } from '@ory/kratos-client'
+import { AxiosResponse } from 'axios'
 import { randomUUID } from 'crypto'
 import { setDefaultResultOrder } from 'dns'
 import http from 'http'
 import { IdentityTraits, KRATOS_IDENTITY_SCHEMA, KratosInvitation } from 'src/domain/identity'
 import { PRODUCTION } from 'src/shared/const'
+
+type KratosListHeaders = {
+  link?: string
+}
+
+const KRATOS_LIST_REL_NEXT = '; rel="next"'
 
 @Injectable()
 export default class KratosService {
@@ -26,17 +33,60 @@ export default class KratosService {
   }
 
   async getIdentityByEmail(email: string): Promise<Identity> {
-    const identities = await this.identity.listIdentities()
+    const identities = await this.identity.listIdentities({
+      credentialsIdentifier: email,
+    })
+
     return identities.data.find(user => {
       const traits = user.traits as IdentityTraits
       return traits.email === email
     })
   }
 
-  async getIdentitiesByIds(ids: Set<string>): Promise<Map<string, Identity>> {
-    const identities = await this.identity.listIdentities()
+  async getIdentitiesByIds(identityIds: Set<string>): Promise<Map<string, Identity>> {
+    const result: Map<string, Identity> = new Map()
 
-    return new Map(identities.data.filter(it => ids.has(it.id)).map(it => [it.id, it]))
+    let identities: Pick<AxiosResponse<Identity[]>, 'data' | 'headers'> = null
+    do {
+      if (!identities) {
+        // eslint-disable-next-line no-await-in-loop
+        identities = await this.identity.listIdentities({
+          perPage: 128,
+        })
+      } else {
+        const headers = identities.headers as KratosListHeaders
+
+        const nextRel = headers.link
+          ?.split(',')
+          ?.find(it => it.endsWith(KRATOS_LIST_REL_NEXT))
+          ?.trim()
+        if (!nextRel) {
+          break
+        }
+
+        const nextLink = nextRel.substring(1, nextRel.length - KRATOS_LIST_REL_NEXT.length - 1)
+        if (!nextLink) {
+          break
+        }
+
+        const url = new URL(nextLink)
+
+        // eslint-disable-next-line no-await-in-loop
+        identities = await this.identity.listIdentities(undefined, {
+          params: Object.entries(url.searchParams),
+        })
+      }
+
+      identities.data.forEach(it => {
+        const { id } = it
+        if (identityIds.has(id)) {
+          result.set(id, it)
+          identityIds.delete(id)
+        }
+      })
+    } while (identityIds.size > 0)
+
+    return result
   }
 
   async getSessionsById(id: string, activeOnly?: boolean): Promise<Session[]> {
@@ -54,6 +104,7 @@ export default class KratosService {
         return [it, sessions]
       }),
     )
+
     return new Map(data)
   }
 
@@ -99,17 +150,6 @@ export default class KratosService {
     })
 
     return res.data
-  }
-
-  async getIdentityIdsByEmail(email: string): Promise<string[]> {
-    const identitites = await this.identity.listIdentities()
-
-    return identitites.data
-      .filter(it => {
-        const traits = it.traits as IdentityTraits
-        return traits.email.includes(email)
-      })
-      .map(it => it.id)
   }
 
   async getSessionByCookie(cookie: string): Promise<Session> {

--- a/web/crux/src/shared/const.ts
+++ b/web/crux/src/shared/const.ts
@@ -32,3 +32,5 @@ export const API_CREATED_LOCATION_HEADERS = {
 }
 
 export const UID_MAX = 2147483647
+
+export const KRATOS_LIST_PAGE_SIZE = 128


### PR DESCRIPTION
Fix an issue with the audit log, where the `KratosService` was not able to provide user info after the 250th user.