### PR TITLE
fix(crane): rename clusterrole RBAC in install script

### DIFF
--- a/web/crux/assets/install-script/install-k8s.sh.hbr
+++ b/web/crux/assets/install-script/install-k8s.sh.hbr
@@ -31,10 +31,11 @@ rules:
   apiGroups:
   - ""
   resources:
-  - pvc
+  - persistentvolumeclaims
   verbs:
   - get
   - list
+  - patch
   - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -78,19 +79,6 @@ aggregationRule:
   - matchLabels:
       rbac.dyrector.io/crane: "restricted-api-access"
 rules: []
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: dyrectorio-crane
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: dyrectorio-crane
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: dyrectorio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This removes a duplication and add the correct name for PVCs for cranes aggregated read-only cluster role.