### PR TITLE
refactor: internal/helper/image_unit_test : use table driven tests

### DIFF
--- a/golang/internal/helper/image/image_unit_test.go
+++ b/golang/internal/helper/image/image_unit_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 type RegistryTestCase struct {
+	Name        string
 	Registry    *string
 	RegistryUrl *string
 	ExpectedUrl string
@@ -23,21 +24,25 @@ type RegistryTestCase struct {
 func TestRegistryWithTable(t *testing.T) {
 	testCases := []RegistryTestCase{
 		{
+			Name:        "Test registry url",
 			Registry:    pointer.NewPTR[string](""),
 			RegistryUrl: pointer.NewPTR[string]("test"),
 			ExpectedUrl: "test",
 		},
 		{
+			Name:        "Test registry url priority",
 			Registry:    pointer.NewPTR[string]("other"),
 			RegistryUrl: pointer.NewPTR[string]("test"),
 			ExpectedUrl: "test",
 		},
 		{
+			Name:        "Test registry url empty",
 			Registry:    nil,
 			RegistryUrl: nil,
 			ExpectedUrl: "",
 		},
 		{
+			Name:        "Test registry url registry",
 			Registry:    pointer.NewPTR[string]("other"),
 			RegistryUrl: nil,
 			ExpectedUrl: "other",
@@ -45,14 +50,16 @@ func TestRegistryWithTable(t *testing.T) {
 	}
 
 	for _, tC := range testCases {
-		if tC.RegistryUrl == nil {
-			url := imageHelper.GetRegistryURL(tC.Registry, nil)
-			assert.Equal(t, url, tC.ExpectedUrl)
-		} else {
-			auth := &imageHelper.RegistryAuth{URL: *tC.RegistryUrl}
-			url := imageHelper.GetRegistryURL(tC.Registry, auth)
-			assert.Equal(t, url, tC.ExpectedUrl)
-		}
+		t.Run(tC.Name, func(t *testing.T) {
+			if tC.RegistryUrl == nil {
+				url := imageHelper.GetRegistryURL(tC.Registry, nil)
+				assert.Equal(t, url, tC.ExpectedUrl)
+			} else {
+				auth := &imageHelper.RegistryAuth{URL: *tC.RegistryUrl}
+				url := imageHelper.GetRegistryURL(tC.Registry, auth)
+				assert.Equal(t, url, tC.ExpectedUrl)
+			}
+		})
 	}
 }
 

--- a/golang/internal/helper/image/image_unit_test.go
+++ b/golang/internal/helper/image/image_unit_test.go
@@ -13,35 +13,50 @@ import (
 	"github.com/dyrector-io/dyrectorio/protobuf/go/agent"
 )
 
-func TestRegistryUrl(t *testing.T) {
-	auth := &imageHelper.RegistryAuth{
-		URL: "test",
+type RegistryTestCase struct {
+	Registry    *string
+	RegistryUrl *string
+	ExpectedUrl string
+}
+
+func NewPTR[T any](value T) *T {
+	return &value
+}
+
+func TestRegistryWithTable(t *testing.T) {
+	testCases := []RegistryTestCase{
+		{
+			Registry:    NewPTR[string](""),
+			RegistryUrl: NewPTR[string]("test"),
+			ExpectedUrl: "test",
+		},
+		{
+			Registry:    NewPTR[string]("other"),
+			RegistryUrl: NewPTR[string]("test"),
+			ExpectedUrl: "test",
+		},
+		{
+			Registry:    nil,
+			RegistryUrl: nil,
+			ExpectedUrl: "",
+		},
+		{
+			Registry:    NewPTR[string]("other"),
+			RegistryUrl: nil,
+			ExpectedUrl: "other",
+		},
 	}
 
-	url := imageHelper.GetRegistryURL(nil, auth)
-	assert.Equal(t, url, "test")
-}
-
-func TestRegistryUrlPriority(t *testing.T) {
-	registry := "other"
-	auth := &imageHelper.RegistryAuth{
-		URL: "test",
+	for _, tC := range testCases {
+		if tC.RegistryUrl == nil {
+			url := imageHelper.GetRegistryURL(tC.Registry, nil)
+			assert.Equal(t, url, tC.ExpectedUrl)
+		} else {
+			auth := &imageHelper.RegistryAuth{URL: *tC.RegistryUrl}
+			url := imageHelper.GetRegistryURL(tC.Registry, auth)
+			assert.Equal(t, url, tC.ExpectedUrl)
+		}
 	}
-
-	url := imageHelper.GetRegistryURL(&registry, auth)
-	assert.Equal(t, url, "test")
-}
-
-func TestRegistryUrlRegistry(t *testing.T) {
-	registry := "other"
-
-	url := imageHelper.GetRegistryURL(&registry, nil)
-	assert.Equal(t, url, "other")
-}
-
-func TestRegistryUrlEmpty(t *testing.T) {
-	url := imageHelper.GetRegistryURL(nil, nil)
-	assert.Equal(t, url, "")
 }
 
 func TestProtoRegistryUrl(t *testing.T) {

--- a/golang/internal/helper/image/image_unit_test.go
+++ b/golang/internal/helper/image/image_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	imageHelper "github.com/dyrector-io/dyrectorio/golang/internal/helper/image"
+	"github.com/dyrector-io/dyrectorio/golang/internal/pointer"
 	"github.com/dyrector-io/dyrectorio/protobuf/go/agent"
 )
 
@@ -19,20 +20,16 @@ type RegistryTestCase struct {
 	ExpectedUrl string
 }
 
-func NewPTR[T any](value T) *T {
-	return &value
-}
-
 func TestRegistryWithTable(t *testing.T) {
 	testCases := []RegistryTestCase{
 		{
-			Registry:    NewPTR[string](""),
-			RegistryUrl: NewPTR[string]("test"),
+			Registry:    pointer.NewPTR[string](""),
+			RegistryUrl: pointer.NewPTR[string]("test"),
 			ExpectedUrl: "test",
 		},
 		{
-			Registry:    NewPTR[string]("other"),
-			RegistryUrl: NewPTR[string]("test"),
+			Registry:    pointer.NewPTR[string]("other"),
+			RegistryUrl: pointer.NewPTR[string]("test"),
 			ExpectedUrl: "test",
 		},
 		{
@@ -41,7 +38,7 @@ func TestRegistryWithTable(t *testing.T) {
 			ExpectedUrl: "",
 		},
 		{
-			Registry:    NewPTR[string]("other"),
+			Registry:    pointer.NewPTR[string]("other"),
 			RegistryUrl: nil,
 			ExpectedUrl: "other",
 		},

--- a/golang/internal/pointer/pointer.go
+++ b/golang/internal/pointer/pointer.go
@@ -1,8 +1,6 @@
 package pointer
 
-/*
- * Creates a new pointer of type T
- */
+// Creates a new pointer of type T
 func NewPTR[T any](value T) *T {
 	return &value
 }

--- a/golang/internal/pointer/pointer.go
+++ b/golang/internal/pointer/pointer.go
@@ -1,0 +1,8 @@
+package pointer
+
+/*
+ * Creates a new pointer of type T
+ */
+func NewPTR[T any](value T) *T {
+	return &value
+}

--- a/golang/internal/pointer/pointer_test.go
+++ b/golang/internal/pointer/pointer_test.go
@@ -1,0 +1,15 @@
+package pointer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPTR(t *testing.T) {
+	sPtr := NewPTR[string]("")
+	assert.Equal(t, *sPtr, "")
+
+	iPtr := NewPTR[int](120)
+	assert.Equal(t, *iPtr, 120)
+}


### PR DESCRIPTION
Fixes #832

Unit tests were spread across various functions, but most of them can be organized into table driven test cases.