### PR TITLE
fix(agent): add capital image name handling

### DIFF
--- a/golang/internal/helper/image/image.go
+++ b/golang/internal/helper/image/image.go
@@ -348,8 +348,12 @@ func checkRemote(ctx context.Context, check remoteCheck) (err error) {
 	return errDigestsMatching
 }
 
+func ParseReference(image string) (reference.Reference, error) {
+	return reference.ParseAnyReference(strings.ToLower(image))
+}
+
 func ExpandImageName(imageWithTag string) (string, error) {
-	ref, err := reference.ParseAnyReference(imageWithTag)
+	ref, err := ParseReference(imageWithTag)
 	if err != nil {
 		return "", err
 	}
@@ -367,7 +371,7 @@ func ExpandImageName(imageWithTag string) (string, error) {
 }
 
 func ExpandImageNameWithTag(image, tag string) (string, error) {
-	ref, err := reference.ParseAnyReference(image)
+	ref, err := ParseReference(image)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We found that on GitHub the organization can have uppercase letters, but the images on ghcr.io will not have uppercase, as per standards.
[Specs](https://github.com/moby/moby/blob/master/image/spec/spec.md).

