### PR TITLE
fix: unique key value input error message updates

### DIFF
--- a/web/crux-ui/src/components/projects/versions/deployments/instances/use-instance-state.ts
+++ b/web/crux-ui/src/components/projects/versions/deployments/instances/use-instance-state.ts
@@ -29,7 +29,7 @@ export type InstanceState = {
 }
 
 export type InstanceActions = {
-  resetSection: (section: ImageConfigProperty) => InstanceContainerConfigData
+  resetSection: (section: ImageConfigProperty) => void
   onPatch: (newConfig: Partial<ContainerConfigData>) => void
   onParseError: (error: Error) => void
 }


### PR DESCRIPTION
Fixes a bug where duplicated key error messages got stuck while multiple users edited the same container config.