### PR TITLE
cicd: restore pipeline change tracking

### DIFF
--- a/.github/workflows/product_builder.yaml
+++ b/.github/workflows/product_builder.yaml
@@ -78,12 +78,16 @@ jobs:
           filters: |
             agents:
               - '${{ env.GOLANG_WORKING_DIRECTORY }}/**'
+              - '.github/workflows/product_builder.yaml'
             crux:
               - '${{ env.CRUX_WORKING_DIRECTORY }}/**'
+              - '.github/workflows/product_builder.yaml'
             cruxui:
               - '${{ env.CRUX_UI_WORKING_DIRECTORY }}/**'
+              - '.github/workflows/product_builder.yaml'
             kratos:
               - '${{ env.KRATOS_WORKING_DIRECTORY }}/**'
+              - '.github/workflows/product_builder.yaml'
       - name: Setting a buildtag
         id: settag
         working-directory: ${{ env.WORKFLOWS_WORKING_DIRECTORY }}


### PR DESCRIPTION
Add back the `product_builder.yaml` to the `gather_changes` job.