### PR TITLE
fix(crux-ui): hide change credentials field when creating a registry or a storage

### DIFF
--- a/web/crux-ui/src/components/registries/registry-fields/github-registry-field.tsx
+++ b/web/crux-ui/src/components/registries/registry-fields/github-registry-field.tsx
@@ -56,13 +56,16 @@ const GithubRegistryFields = (props: EditRegistryTypeProps<EditableGithubRegistr
         message={errors.imageNamePrefix}
       />
 
-      <DyoToggle
-        className="mt-8"
-        name="changeCredentials"
-        label={t('common:changeCredentials')}
-        checked={values.changeCredentials}
-        setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
-      />
+      {editing && (
+        <DyoToggle
+          className="mt-8"
+          disabled={!editing}
+          name="changeCredentials"
+          label={t('common:changeCredentials')}
+          checked={values.changeCredentials}
+          setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
+        />
+      )}
 
       {values.changeCredentials && (
         <>

--- a/web/crux-ui/src/components/registries/registry-fields/gitlab-registry-field.tsx
+++ b/web/crux-ui/src/components/registries/registry-fields/gitlab-registry-field.tsx
@@ -97,13 +97,16 @@ const GitlabRegistryFields = (props: EditRegistryTypeProps<EditableGitlabRegistr
         </>
       )}
 
-      <DyoToggle
-        className="mt-8"
-        name="changeCredentials"
-        label={t('common:changeCredentials')}
-        checked={values.changeCredentials}
-        setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
-      />
+      {editing && (
+        <DyoToggle
+          className="mt-8"
+          disabled={!editing}
+          name="changeCredentials"
+          label={t('common:changeCredentials')}
+          checked={values.changeCredentials}
+          setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
+        />
+      )}
 
       {values.changeCredentials && (
         <>

--- a/web/crux-ui/src/components/registries/registry-fields/google-registry-field.tsx
+++ b/web/crux-ui/src/components/registries/registry-fields/google-registry-field.tsx
@@ -81,13 +81,16 @@ const GoogleRegistryFields = (props: EditRegistryTypeProps<EditableGoogleRegistr
 
       {!values.public && (
         <>
-          <DyoToggle
-            className="mt-8"
-            name="changeCredentials"
-            label={t('common:changeCredentials')}
-            checked={values.changeCredentials}
-            setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
-          />
+          {editing && (
+            <DyoToggle
+              className="mt-8"
+              disabled={!editing}
+              name="changeCredentials"
+              label={t('common:changeCredentials')}
+              checked={values.changeCredentials}
+              setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
+            />
+          )}
 
           {values.changeCredentials && (
             <>

--- a/web/crux-ui/src/components/registries/registry-fields/hub-registry-fields.tsx
+++ b/web/crux-ui/src/components/registries/registry-fields/hub-registry-fields.tsx
@@ -49,13 +49,16 @@ const HubRegistryFields = (props: EditRegistryTypeProps<EditableHubRegistryDetai
 
       {!values.public && (
         <>
-          <DyoToggle
-            className="mt-8"
-            name="changeCredentials"
-            label={t('common:changeCredentials')}
-            checked={values.changeCredentials}
-            setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
-          />
+          {editing && (
+            <DyoToggle
+              className="mt-8"
+              disabled={!editing}
+              name="changeCredentials"
+              label={t('common:changeCredentials')}
+              checked={values.changeCredentials}
+              setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
+            />
+          )}
 
           {values.changeCredentials && (
             <>

--- a/web/crux-ui/src/components/registries/registry-fields/v2-registry-field.tsx
+++ b/web/crux-ui/src/components/registries/registry-fields/v2-registry-field.tsx
@@ -46,13 +46,16 @@ const V2RegistryFields = (props: EditRegistryTypeProps<EditableV2RegistryDetails
 
       {!values.public && (
         <>
-          <DyoToggle
-            className="mt-8"
-            name="changeCredentials"
-            label={t('common:changeCredentials')}
-            checked={values.changeCredentials}
-            setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
-          />
+          {editing && (
+            <DyoToggle
+              className="mt-8"
+              disabled={!editing}
+              name="changeCredentials"
+              label={t('common:changeCredentials')}
+              checked={values.changeCredentials}
+              setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
+            />
+          )}
 
           {values.changeCredentials && (
             <>

--- a/web/crux-ui/src/components/storages/edit-storage-card.tsx
+++ b/web/crux-ui/src/components/storages/edit-storage-card.tsx
@@ -159,13 +159,16 @@ const EditStorageCard = (props: EditStorageCardProps) => {
 
           {!values.public && (
             <>
-              <DyoToggle
-                className="mt-8"
-                name="changeCredentials"
-                label={t('common:changeCredentials')}
-                checked={values.changeCredentials}
-                setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
-              />
+              {editing && (
+                <DyoToggle
+                  className="mt-8"
+                  disabled={!editing}
+                  name="changeCredentials"
+                  label={t('common:changeCredentials')}
+                  checked={values.changeCredentials}
+                  setFieldValue={formikSetFieldValueOrIgnore(formik, !editing)}
+                />
+              )}
 
               {values.changeCredentials && (
                 <>


### PR DESCRIPTION
Hide the change credentials toggle, while creating a registry or a storage