### PR TITLE
fix(crux): crash while selecting tag for images without an environment

### DIFF
--- a/web/crux/src/app/image/image.service.ts
+++ b/web/crux/src/app/image/image.service.ts
@@ -254,11 +254,12 @@ export default class ImageService {
   private static mergeEnvironmentsRules(
     environment: UniqueKeyValue[],
     rules: Record<string, EnvironmentRule>,
-  ): UniqueKeyValue[] {
-    const currentEnv = environment.reduce((map, it) => {
+  ): UniqueKeyValue[] | null {
+
+    const currentEnv = environment?.reduce((map, it) => {
       map[it.key] = it
       return map
-    }, {})
+    }, {}) ?? {}
 
     const mergedEnv = Object.entries(rules).reduce((map, it) => {
       const [key, rule] = it


### PR DESCRIPTION
Fix an internal server error, when trying to select a tag for a newly added image.