### PR TITLE
feat(cli): add frontend for crux encryption-key generation

### DIFF
--- a/golang/pkg/cli/cli.go
+++ b/golang/pkg/cli/cli.go
@@ -55,6 +55,7 @@ func InitCLI() *ucli.App {
 				Aliases: []string{"v"},
 				Action:  run,
 			},
+			GetGenerateCommand(),
 		},
 		Flags: []ucli.Flag{
 			&ucli.BoolFlag{

--- a/golang/pkg/cli/generate.go
+++ b/golang/pkg/cli/generate.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"fmt"
+
+	ucli "github.com/urfave/cli/v2"
+)
+
+const (
+	GenerateCommand = "generate"
+)
+
+func GetGenerateCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:        GenerateCommand,
+		Aliases:     []string{"g", "gen"},
+		Action:      ucli.ShowSubcommandHelp,
+		Usage:       "dyo gen <component> <....>",
+		UsageText:   "dyo gen crux encryption-key",
+		Description: "Some components need tokens or keys, these helpers could be used to generate them",
+		Subcommands: []*ucli.Command{{
+			Name:   "crux",
+			Action: ucli.ShowSubcommandHelp,
+			Usage:  "dyo gen crux encryption-key",
+			Subcommands: []*ucli.Command{{
+				Name: "encryption-key",
+				Action: func(_ *ucli.Context) error {
+					//nolint:forbidigo
+					fmt.Print(generateCruxEncryptionKey())
+					return nil
+				},
+			}},
+		}},
+	}
+}


### PR DESCRIPTION
Added command so that it could be called as:

```
docker run --rm ghcr.io/dyrector-io/dyrectorio/cli/dyo:latest generate crux encryption-key
```

This could be used to generate commands, also this could be extended for other similar variables.