### PR TITLE
doc(crux): add extra info encrpytion gey generation

### DIFF
--- a/web/crux/.env.example
+++ b/web/crux/.env.example
@@ -26,6 +26,8 @@ CRUX_AGENT_ADDRESS=localhost:5000
 JWT_SECRET=jwt-secret-token
 
 # Secret key for encrypting stored credentials
+# can be generated using the CLI
+# docker run --rm ghcr.io/dyrector-io/dyrectorio/cli/dyo:latest generate crux encryption-key
 ENCRYPTION_SECRET_KEY=
 
 # The old encryption key used to decrypt existing secrets while rotating keys

--- a/web/crux/.env.example
+++ b/web/crux/.env.example
@@ -26,8 +26,8 @@ CRUX_AGENT_ADDRESS=localhost:5000
 JWT_SECRET=jwt-secret-token
 
 # Secret key for encrypting stored credentials
-# can be generated using the CLI
-# docker run --rm ghcr.io/dyrector-io/dyrectorio/cli/dyo:latest generate crux encryption-key
+# Can be generated using the CLI
+# Example: docker run --rm ghcr.io/dyrector-io/dyrectorio/cli/dyo:latest generate crux encryption-key
 ENCRYPTION_SECRET_KEY=
 
 # The old encryption key used to decrypt existing secrets while rotating keys


### PR DESCRIPTION
The file itself is linked to the docs, so `.env.example` files have to be descriptive, since they serve as living documentation.