### PR TITLE
feat(crux-ui): add tooltip for container names in node container list

### DIFF
--- a/web/crux-ui/src/components/nodes/node-containers-list.tsx
+++ b/web/crux-ui/src/components/nodes/node-containers-list.tsx
@@ -55,7 +55,9 @@ const NodeContainersList = (props: NodeContainersListProps) => {
           sortField={(it: Container) => imageName(it.imageName, it.imageTag)}
           sort={sortString}
           bodyClassName="overflow-hidden truncate"
-          body={(it: Container) => imageName(it.imageName, it.imageTag)}
+          body={(it: Container) => (
+            <span title={imageName(it.imageName, it.imageTag)}>{imageName(it.imageName, it.imageTag)}</span>
+          )}
         />
         <DyoColumn
           header={t('common:state')}


### PR DESCRIPTION
Add  a tooltip for the container names in node container list