### PR TITLE
fix(crux-ui): active menu

### DIFF
--- a/web/crux-ui/src/components/main/nav-button.tsx
+++ b/web/crux-ui/src/components/main/nav-button.tsx
@@ -15,7 +15,7 @@ const NavButton = (props: NavButtonProps) => {
 
   const router = useRouter()
 
-  const active = router.pathname.startsWith(href)
+  const active = router.asPath.startsWith(href)
 
   return (
     <>


### PR DESCRIPTION
Now the active item is highlighted on the side-menu again.