### PR TITLE
fix(crux-ui): overwritten deployment secrets

### DIFF
--- a/web/crux-ui/src/components/projects/versions/deployments/instances/use-instance-state.ts
+++ b/web/crux-ui/src/components/projects/versions/deployments/instances/use-instance-state.ts
@@ -1,5 +1,6 @@
 import {
   ContainerConfigData,
+  GetInstanceSecretsMessage,
   ImageConfigProperty,
   Instance,
   InstanceContainerConfigData,
@@ -7,11 +8,12 @@ import {
   mergeConfigs,
   MergedContainerConfigData,
   PatchInstanceMessage,
+  WS_TYPE_GET_INSTANCE_SECRETS,
   WS_TYPE_INSTANCE_SECRETS,
   WS_TYPE_PATCH_INSTANCE,
 } from '@app/models'
 import { createContainerConfigSchema, getValidationError } from '@app/validations'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { DeploymentActions, DeploymentState } from '../use-deployment-state'
 import useTranslation from 'next-translate/useTranslation'
 
@@ -50,6 +52,12 @@ const useInstanceState = (options: InstanceStateOptions) => {
 
     setDefinedSecrets(message.keys)
   })
+
+  useEffect(() => {
+    sock.send(WS_TYPE_GET_INSTANCE_SECRETS, {
+      id: instance.id,
+    } as GetInstanceSecretsMessage)
+  }, [instance.id, sock])
 
   const mergedConfig = mergeConfigs(instance.image.config, instance.config)
 

--- a/web/crux-ui/src/components/shared/secret-key-value-input.tsx
+++ b/web/crux-ui/src/components/shared/secret-key-value-input.tsx
@@ -188,14 +188,22 @@ const SecretKeyValueInput = (props: SecretKeyValueInputProps) => {
     let newItems = [...state].filter(it => !isCompletelyEmpty(it))
 
     newItems = await Promise.all(
-      [...newItems].map(
-        async (it): Promise<UniqueSecretKeyValue> => ({
+      [...newItems].map(async (it): Promise<UniqueSecretKeyValue> => {
+        let { value } = it
+        let encryptedWithPublicKey = it.publicKey
+
+        if (!it.encrypted) {
+          value = await encryptWithPGP(it.value, publicKey)
+          encryptedWithPublicKey = publicKey
+        }
+
+        return {
           ...it,
-          value: await encryptWithPGP(it.value, publicKey),
+          value,
           encrypted: true,
-          publicKey,
-        }),
-      ),
+          publicKey: encryptedWithPublicKey,
+        }
+      }),
     )
 
     propsOnSubmit(newItems)


### PR DESCRIPTION
Fixes an issue where adding a secret to the instance config overwrites the exiting ones.