### PR TITLE
fix: add ENCRYPTION_SECRET_KEY to root .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,14 @@ NODE_ENV=production
 
 # You can specify how thorough logging will be
 # Options: verbose, debug, info, warning, error
-# The settings come in a hierarchic order,
-# meaning that in the order above they contain each other
+# The settings come in a hierarchic order, meaning that in the order above they contain each other
 # Example: 'warning' contains 'error'
 LOG_LEVEL=debug
+
+# Secret key for encrypting stored credentials
+# Can be generated using the CLI
+# Example: docker run --rm ghcr.io/dyrector-io/dyrectorio/cli/dyo:latest generate crux encryption-key
+ENCRYPTION_SECRET_KEY=Random_Generate_Key
 
 ## Database passwords
 
@@ -74,8 +78,7 @@ DISABLE_RECAPTCHA=false
 RECAPTCHA_SECRET_KEY=Recaptcha_Secret_Key
 RECAPTCHA_SITE_KEY=Recaptcha_Site_Key
 
-# To turn off quality assurance
-# defaults to false
+# To turn off Quality Assurance (default: false)
 # more info: https://docs.dyrector.io/learn-more/quality-assurance-qa
 # QA_OPT_OUT=true
 


### PR DESCRIPTION
Missing the `ENCRYPTION_SECRET_KEY` key from the root `.env.example`, fixed this.