### PR TITLE
fix(crux): agent token replacement status

### DIFF
--- a/web/crux/src/domain/agent.ts
+++ b/web/crux/src/domain/agent.ts
@@ -142,7 +142,7 @@ export class Agent {
       return 'unreachable'
     }
 
-    if (this.updating) {
+    if (this.updating || !!this.replacementToken) {
       return 'updating'
     }
 
@@ -417,6 +417,11 @@ export class Agent {
     this.connection.onTokenReplaced(token, signedToken)
 
     this.replacementToken = null
+    this.eventChannel.next({
+      id: this.id,
+      status: this.getConnectionStatus(),
+    })
+
     return replacement
   }
 


### PR DESCRIPTION
Fixes an issue, where the agent status was reported as `connected` too early, while the install token was still replacing.