### PR TITLE
fix(crux): get instance config

### DIFF
--- a/web/crux/src/app/deploy/deploy.service.ts
+++ b/web/crux/src/app/deploy/deploy.service.ts
@@ -178,6 +178,7 @@ export default class DeployService {
             registry: true,
           },
         },
+        config: true,
       },
     })
 


### PR DESCRIPTION
Fixes the endpoint `/deployments/:deploymentId/instances/:instanceId` to return the instance config as it supposed to.