### PR TITLE
fix(agent): deprecated types.AuthConfig

### DIFF
--- a/golang/internal/helper/image/image.go
+++ b/golang/internal/helper/image/image.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -419,7 +420,7 @@ func authConfigToBasicAuth(authConfigEncoded string) (string, error) {
 		return "", err
 	}
 
-	var authOpts types.AuthConfig
+	var authOpts registry.AuthConfig
 	err = json.Unmarshal(authConfigJSON, &authOpts)
 	if err != nil {
 		return "", err

--- a/golang/pkg/builder/container/utils.go
+++ b/golang/pkg/builder/container/utils.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/registry"
 
 	"github.com/dyrector-io/dyrectorio/golang/internal/dogger"
 
@@ -19,7 +19,7 @@ func registryAuthBase64(user, password string) string {
 		return ""
 	}
 
-	authConfig := types.AuthConfig{
+	authConfig := registry.AuthConfig{
 		Username: user,
 		Password: password,
 	}
@@ -70,7 +70,6 @@ func ReadDockerLogsFromReadCloser(logs io.ReadCloser, skip, take int) []string {
 		count := binary.BigEndian.Uint32(header[4:])
 		data := make([]byte, count)
 		_, err = logs.Read(data)
-
 		if err != nil {
 			if err != io.EOF {
 				panic(err)


### PR DESCRIPTION
Resolves a go lint issue with the deprecated `types.AuthConfig`