### PR TITLE
fix(crux-ui): add IPv6 listen for dual-stack listening

### DIFF
--- a/web/crux-ui/Dockerfile
+++ b/web/crux-ui/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=BUILDER --chown=node:node /app/.next/static ./.next/static
 USER node
 
 EXPOSE 3000
-ENV HOSTNAME "0.0.0.0"
+ENV HOSTNAME "::"
 ENV PORT 3000
 LABEL org.opencontainers.image.source="https://github.com/dyrector-io/dyrectorio/web/crux-ui"
 


### PR DESCRIPTION
Since **wget** defaults to IPv6 it causes healthcheck to fail, binding dualstack in crux-ui, as it is done in crux addresses the issue.