### PR TITLE
fix(crux-ui): envs split only at the first equals sign

### DIFF
--- a/web/crux-ui/src/components/composer/use-composer-state.ts
+++ b/web/crux-ui/src/components/composer/use-composer-state.ts
@@ -5,6 +5,7 @@ import {
   ConvertedContainer,
   DotEnvironment,
   applyDotEnvToComposeService,
+  envStringToKeyValue,
   mapComposeServices,
   mapKeyValuesToRecord as mapKeyValuesToObject,
 } from '@app/models'
@@ -251,7 +252,7 @@ export const convertEnvFile =
             line = line.substring(0, commentIndex).trim()
           }
 
-          const [key, value] = line.split('=')
+          const [key, value] = envStringToKeyValue(line)
           return [key, value]
         })
         .filter(it => {

--- a/web/crux-ui/src/models/compose.ts
+++ b/web/crux-ui/src/models/compose.ts
@@ -161,7 +161,7 @@ const mapVolume = (volume: string): ContainerConfigVolume => {
     id: uuid(),
     name: path ? name : '',
     path: path || name,
-    type: type && CONTAINER_VOLUME_TYPE_VALUES.includes(type as VolumeType) ? (type as VolumeType) : null,
+    type: type && CONTAINER_VOLUME_TYPE_VALUES.includes(type as VolumeType) ? (type as VolumeType) : 'rwo',
   }
 }
 
@@ -188,9 +188,15 @@ const mapUser = (user: string): number => {
   }
 }
 
+export const envStringToKeyValue = (env: string): [string, string] => {
+  const [key, ...rest] = env.split('=')
+  const value = rest.join('=')
+  return [key, value]
+}
+
 export const mapKeyValuesToRecord = (items: string[] | null): Record<string, string> =>
   items?.reduce((result, it) => {
-    const [key, value] = it.split('=')
+    const [key, value] = envStringToKeyValue(it)
 
     result[key] = value
     return result
@@ -198,7 +204,7 @@ export const mapKeyValuesToRecord = (items: string[] | null): Record<string, str
 
 const mapKeyValues = (items: string[] | null): UniqueKeyValue[] | null =>
   items?.map(it => {
-    const [key, value] = it.split('=')
+    const [key, value] = envStringToKeyValue(it)
 
     return {
       id: uuid(),


### PR DESCRIPTION
- Environment values containing a `=` sign is now being parsed correctly
- Default to rwo for volumes without a type