### PR TITLE
chore: more consistent release generation, adjust lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,12 +39,6 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: github.com/golangci/golangci-lint,github.com/dyrector-io/dyrectorio
-  gomnd:
-    checks:
-      - argument
-      - case
-      - condition
-      - return
   govet:
     enable-all: true
   lll:

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ release: branch-check
 	$(info Do you want to continue? Version will be: $(version) from branch: $(shell git rev-parse --abbrev-ref HEAD))
 	read
 
-	git pull
+	git pull --tags
 
 	@if git checkout -b "release/$(version)"; then \
 		echo "Branch release/$(version) created and checked out"; \


### PR DESCRIPTION
Two minor things:
The `make release` command if executed on different machines ignored the remote tags, because they are not pulled by the script.
The other one addresses a deprecation notice in the golangci configuration.