### PR TITLE
fix(crux-ui): secret releated env keys

### DIFF
--- a/web/crux-ui/src/components/projects/versions/images/config/common-config-section.tsx
+++ b/web/crux-ui/src/components/projects/versions/images/config/common-config-section.tsx
@@ -32,7 +32,14 @@ import {
   mergeConfigs,
 } from '@app/models'
 import { fetcher, toNumber } from '@app/utils'
-import { ContainerConfigValidationErrors, findErrorFor, findErrorStartsWith, matchError } from '@app/validations'
+import {
+  ContainerConfigValidationErrors,
+  findErrorFor,
+  findErrorStartsWith,
+  getValidationError,
+  matchError,
+  unsafeUniqueKeyValuesSchema,
+} from '@app/validations'
 import clsx from 'clsx'
 import useTranslation from 'next-translate/useTranslation'
 import useSWR from 'swr'
@@ -136,6 +143,9 @@ const CommonConfigSection = (props: CommonConfigSectionProps) => {
     }
     onChange(patch)
   }
+
+  const environmentWarning =
+    getValidationError(unsafeUniqueKeyValuesSchema, config.environment, undefined, t)?.message ?? null
 
   return !filterEmpty([...COMMON_CONFIG_PROPERTIES], selectedFilters) ? null : (
     <div className="my-4">
@@ -453,7 +463,8 @@ const CommonConfigSection = (props: CommonConfigSectionProps) => {
                 editorOptions={editorOptions}
                 disabled={disabled}
                 findErrorMessage={index => findErrorStartsWith(fieldErrors, `environment[${index}]`)}
-                message={findErrorFor(fieldErrors, `environment`)}
+                message={findErrorFor(fieldErrors, `environment`) ?? environmentWarning}
+                messageType={!findErrorFor(fieldErrors, `environment`) && environmentWarning ? 'info' : 'error'}
               />
             </div>
           )}

--- a/web/crux-ui/src/validations/common.ts
+++ b/web/crux-ui/src/validations/common.ts
@@ -52,7 +52,7 @@ export const yupErrorTranslate = (error: yup.ValidationError, t: Translate): yup
 }
 
 export const getValidationError = (
-  schema: yup.Schema,
+  schema: yup.AnySchema,
   candidate: any,
   options?: yup.ValidateOptions,
   t?: Translate,

--- a/web/crux-ui/src/validations/container.ts
+++ b/web/crux-ui/src/validations/container.ts
@@ -487,7 +487,7 @@ const testEnvironment = (imageLabels: Record<string, string>) => (arr: UniqueKey
 const createContainerConfigBaseSchema = (imageLabels: Record<string, string>) =>
   yup.object().shape({
     name: matchNoWhitespace(yup.string().required().label('container:common.containerName')),
-    environment: unsafeUniqueKeyValuesSchema
+    environment: uniqueKeyValuesSchema
       .default([])
       .nullable()
       .label('container:common.environment')


### PR DESCRIPTION
Using 'unsafe' environment keys now only shows a warning instead of a blocking error.