### PR TITLE
fix(dagent): change version check to accept version with metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ProtonMail/gopenpgp/v2 v2.7.1
 	github.com/go-playground/validator/v10 v10.12.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
-	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/go-version v1.7.0
 	github.com/ilyakaznacheev/cleanenv v1.4.2
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ilyakaznacheev/cleanenv v1.4.2 h1:nRqiriLMAC7tz7GzjzUTBHfzdzw6SQ7XvTagkFqe/zU=

--- a/golang/internal/runtime/container/container_test.go
+++ b/golang/internal/runtime/container/container_test.go
@@ -107,6 +107,11 @@ var (
 			Info:              getDockerInfoPodman(),
 			MockClientVersion: "4.8.0",
 		},
+		// rhel based distros include additional metadata in version
+		{
+			Info:              getDockerInfoPodman(),
+			MockClientVersion: "4.9.4-rhel",
+		},
 	}
 	testCasesErrnous = []VersionTestCaseWithErr{
 		// server outdated errors


### PR DESCRIPTION
Installing dagent on a RHEL based distribution is not possible because `serverversion is not supported`. The PR addresses the problem.