### PR TITLE
fix(agent): add support for mixed-case image tags

### DIFF
--- a/golang/internal/helper/image/image.go
+++ b/golang/internal/helper/image/image.go
@@ -348,7 +348,7 @@ func checkRemote(ctx context.Context, check remoteCheck) (err error) {
 }
 
 func ParseReference(img string) (reference.Reference, error) {
-	return reference.ParseAnyReference(strings.ToLower(img))
+	return reference.ParseAnyReference(img)
 }
 
 func ExpandImageName(imageWithTag string) (string, error) {

--- a/golang/internal/helper/image/image_unit_test.go
+++ b/golang/internal/helper/image/image_unit_test.go
@@ -192,9 +192,9 @@ func TestExpandImageNameWithTag(t *testing.T) {
 		{
 			name:     "capitalsHandled",
 			desc:     "with capitals in the image parsing works smoothly",
-			image:    "my-reg.com/Library/nginx:my-tag",
-			tag:      "tag-4",
-			expImage: "my-reg.com/library/nginx:tag-4",
+			image:    "my-reg.com/library/nginx",
+			tag:      "Tag-4",
+			expImage: "my-reg.com/library/nginx:Tag-4",
 		},
 	}
 	for _, tC := range testCases {

--- a/golang/internal/helper/image/image_unit_test.go
+++ b/golang/internal/helper/image/image_unit_test.go
@@ -127,10 +127,10 @@ func TestExpandImageName(t *testing.T) {
 			expImage: "my-reg.com/library/nginx:my-tag",
 		},
 		{
-			name:     "ifNotLowerCaseThatisFine",
-			desc:     "image is expanded regardless not just lowercase characters were provided",
-			image:    "ghcr.io/Test-Org/image:latest",
-			expImage: "ghcr.io/test-org/image:latest",
+			name:     "ifNotLowerCaseThatisFineAndRespected",
+			desc:     "image is expanded regardless not just lowercase characters were provided, tags can be uppercase",
+			image:    "ghcr.io/test-org/image:MixedCase",
+			expImage: "ghcr.io/test-org/image:MixedCase",
 		},
 	}
 	for _, tC := range testCases {


### PR DESCRIPTION
Uppercase letters in image names are not valid, however tags **can** be. 