### PR TITLE
feat: add validation to /api/$/projects/$/versions/$/images API

### DIFF
--- a/web/crux/src/app/image/image.http.controller.ts
+++ b/web/crux/src/app/image/image.http.controller.ts
@@ -35,6 +35,7 @@ import ImageService from './image.service'
 import ImageAddToVersionValidationInterceptor from './interceptors/image.add-images.interceptor'
 import DeleteImageValidationInterceptor from './interceptors/image.delete.interceptor'
 import OrderImagesValidationInterceptor from './interceptors/image.order.interceptor'
+import ValidateNonEmptyArrayPipe from './pipes/image.add.pipe'
 
 const PARAM_TEAM_SLUG = 'teamSlug'
 const PARAM_IMAGE_ID = 'imageId'
@@ -115,7 +116,7 @@ export default class ImageHttpController {
     @TeamSlug() teamSlug: string,
     @ProjectId() projectId: string,
     @VersionId() versionId: string,
-    @Body() request: AddImagesDto[],
+    @Body(new ValidateNonEmptyArrayPipe()) request: AddImagesDto[],
     @IdentityFromRequest() identity: Identity,
   ): Promise<CreatedResponse<ImageDto[]>> {
     const images = await this.service.addImagesToVersion(teamSlug, versionId, request, identity)

--- a/web/crux/src/app/image/pipes/image.add.pipe.ts
+++ b/web/crux/src/app/image/pipes/image.add.pipe.ts
@@ -1,0 +1,12 @@
+import { Injectable, PipeTransform } from '@nestjs/common'
+import { CruxBadRequestException } from 'src/exception/crux-exception'
+
+@Injectable()
+export default class ValidateNonEmptyArrayPipe implements PipeTransform {
+  transform(body: any) {
+    if (!Array.isArray(body) || body.length === 0) {
+      throw new CruxBadRequestException({ message: 'Request body must be a non-empty array.', property: body })
+    }
+    return body
+  }
+}


### PR DESCRIPTION
As the title says, we have a lack of validation in the `/api/$/projects/$/versions/$/images` API route. 