### PR TITLE
fix(dagent): adjust of env variables, empty string as valid value

### DIFF
--- a/golang/internal/util/string.go
+++ b/golang/internal/util/string.go
@@ -14,6 +14,12 @@ func JoinV(separator string, items ...string) string {
 	return strings.Join(clean, separator)
 }
 
+// JoinV is a variadic alternative for strings.Join
+// it keeps empty values
+func JoinVEmpty(separator string, items ...string) string {
+	return strings.Join(append([]string{}, items...), separator)
+}
+
 // variadic string fallback, accepting string params
 // returns the first non-empty value or empty if there is none
 func Fallback(str ...string) string {

--- a/golang/internal/util/string_test.go
+++ b/golang/internal/util/string_test.go
@@ -9,15 +9,20 @@ import (
 )
 
 func TestJoinV(t *testing.T) {
-	assert.Equal(t, util.JoinV(""), "")
-	assert.Equal(t, util.JoinV(":", "o", "o"), "o:o")
-	assert.Equal(t, util.JoinV("\\", "i"), "i")
-	assert.Equal(t, util.JoinV("/", "i", "i", "i"), "i/i/i")
+	assert.Equal(t, "", util.JoinV(""))
+	assert.Equal(t, "o:o", util.JoinV(":", "o", "o"))
+	assert.Equal(t, "i", util.JoinV("\\", "i"))
+	assert.Equal(t, "i/i/i", util.JoinV("/", "i", "i", "i"))
+	assert.Equal(t, "ENVKEY", util.JoinV("=", "ENVKEY", "")) // this is intentionally a bad example
+}
+
+func TestJoinVEmpty(t *testing.T) {
+	assert.Equal(t, "ENVKEY=", util.JoinVEmpty("=", "ENVKEY", "")) // this is intentionally a bad example
 }
 
 func TestFallback(t *testing.T) {
-	assert.Equal(t, util.Fallback(""), "")
-	assert.Equal(t, util.Fallback("1", "2", "3"), "1")
-	assert.Equal(t, util.Fallback("", "2"), "2")
-	assert.Equal(t, util.Fallback("", "", "", "4"), "4")
+	assert.Equal(t, "", util.Fallback(""))
+	assert.Equal(t, "1", util.Fallback("1", "2", "3"))
+	assert.Equal(t, "2", util.Fallback("", "2"))
+	assert.Equal(t, "4", util.Fallback("", "", "", "4"))
 }

--- a/golang/pkg/dagent/utils/docker.go
+++ b/golang/pkg/dagent/utils/docker.go
@@ -617,7 +617,7 @@ func EnvMapToSlice(envs map[string]string) []string {
 	arr := []string{}
 
 	for key, value := range envs {
-		arr = append(arr, util.JoinV("=", key, value))
+		arr = append(arr, util.JoinVEmpty("=", key, value))
 	}
 
 	return arr


### PR DESCRIPTION
I just ran into the issue where I wanted to override an environment variable with an empty string and it was not working properly. The change addresses the issue.