### PR TITLE
fix: add client & server side keepalive

### DIFF
--- a/golang/internal/config/config.go
+++ b/golang/internal/config/config.go
@@ -37,7 +37,7 @@ type CommonConfiguration struct {
 	//nolint:lll
 	ImportContainerImage     string        `yaml:"importContainerImage"     env:"IMPORT_CONTAINER_IMAGE"      env-default:"rclone/rclone:1.57.0"`
 	ReadHeaderTimeout        time.Duration `yaml:"readHeaderTimeout"        env:"READ_HEADER_TIMEOUT"         env-default:"15s"`
-	GrpcKeepalive            time.Duration `yaml:"grpcKeepalive"            env:"GRPC_KEEPALIVE"              env-default:"60s"`
+	GrpcKeepalive            time.Duration `yaml:"grpcKeepalive"            env:"GRPC_KEEPALIVE"              env-default:"30s"`
 	DefaultTimeout           time.Duration `yaml:"defaultTimeout"           env:"DEFAULT_TIMEOUT"             env-default:"5s"`
 	DebugUpdateUseContainers bool          `yaml:"debugUpdateUseContainers" env:"DEBUG_UPDATE_USE_CONTAINERS" env-default:"true"`
 	DebugUpdateAlways        bool          `yaml:"debugUpdateAlways"        env:"DEBUG_UPDATE_ALWAYS"         env-default:"false"`

--- a/web/crux/.env.example
+++ b/web/crux/.env.example
@@ -70,6 +70,13 @@ AGENT_CALLBACK_TIMEOUT=5000
 # defaults to 4 Megabytes
 # MAX_GRPC_RECEIVE_MESSAGE_LENGTH=4194304
 
+# GRPC Timeout values and their respective defaults
+# 
+# GRPC_KEEPALIVE_TIMEOUT_MS=5000
+# GRPC_KEEPALIVE_TIME_MS=30000
+# HTTP2_MINPINGINTERVAL_MS=30000
+# HTTP2_MINTIMEBETWEENPINGS_MS=10000
+
 # For overriding the node DNS result order
 # regardless of the NODE_ENV value
 # It may be necessary for running the e2e tests,

--- a/web/crux/src/config/app.config.ts
+++ b/web/crux/src/config/app.config.ts
@@ -47,8 +47,13 @@ const configSchema = yup.object({
   QA_GROUP_NAME: yup.string().optional(),
 
   MAX_CONTAINER_LOG_TAKE: yup.number().optional(),
-  AGENT_CALLBACK_TIMEOUT: yup.number().optional(),
-  MAX_GRPC_RECEIVE_MESSAGE_LENGTH: yup.number().optional(),
+  AGENT_CALLBACK_TIMEOUT: yup.number().positive().optional(),
+  MAX_GRPC_RECEIVE_MESSAGE_LENGTH: yup.number().positive().optional(),
+
+  GRPC_KEEPALIVE_TIMEOUT_MS: yup.number().positive().min(1000).optional(), // 5000
+  GRPC_KEEPALIVE_TIME_MS: yup.number().positive().min(10000).optional(), // 30000
+  HTTP2_MINPINGINTERVAL_MS: yup.number().positive().min(5000).optional(), // 30000
+  HTTP2_MINTIMEBETWEENPINGS_MS: yup.number().positive().min(1000).optional(), // 10000
 })
 
 class InvalidEnvironmentError extends Error {

--- a/web/crux/src/main.ts
+++ b/web/crux/src/main.ts
@@ -26,8 +26,6 @@ import prismaBootstrap from './services/prisma.bootstrap'
 import { productionEnvironment } from './shared/config'
 import DyoWsAdapter from './websockets/dyo.ws.adapter'
 
-const HOUR_IN_MS: number = 60 * 60 * 1000
-
 const CRUX_COMMANDS = ['serve', 'encrypt'] as const
 type CruxCommand = (typeof CRUX_COMMANDS)[number]
 
@@ -131,7 +129,13 @@ const serve = async () => {
     options: {
       package: ['agent'],
       protoPath: [join(__dirname, '../proto/agent.proto'), join(__dirname, '../proto/common.proto')],
-      keepalive: { keepaliveTimeoutMs: HOUR_IN_MS },
+      keepalive: {
+        keepaliveTimeoutMs: configService.get<number>('GRPC_KEEPALIVE_TIMEOUT_MS') ?? 5 * 1000,
+        keepaliveTimeMs: configService.get<number>('GRPC_KEEPALIVE_TIME_MS') ?? 30 * 1000,
+        keepalivePermitWithoutCalls: 1,
+        http2MinPingIntervalWithoutDataMs: configService.get<number>('HTTP2_MINPINGINTERVAL_MS') ?? 30 * 1000,
+        http2MinTimeBetweenPingsMs: configService.get<number>('HTTP2_MINTIMEBETWEENPINGS_MS') ?? 10 * 1000,
+      },
       // tls termination occurs at the reverse proxy
       credentials: ServerCredentials.createInsecure(),
       url: `0.0.0.0:${agentPort}`,


### PR DESCRIPTION
Using Cloudflare, the default 100 seconds timeout applied causing agents to disconnect every 100 minute.
The change puts reasonable lower keepalive number for both client and server side to address the issue.