### PR TITLE
feat(web): merge postgress instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,12 +35,14 @@ LOG_LEVEL=debug
 # Example: docker run --rm ghcr.io/dyrector-io/dyrectorio/cli/dyo:latest generate crux encryption-key
 ENCRYPTION_SECRET_KEY=Random_Generate_Key
 
-# # Database passwords
+# # Database passwords and infos
 
 # This value is the password to crux's database
 CRUX_POSTGRES_PASSWORD=Random_Generated_String
 # This value is the password to Kratos' database
 KRATOS_POSTGRES_PASSWORD=Random_Generated_String
+# This value is the password to root user
+POSTGRES_ROOT_PASSWORD=Random_Generated_String
 
 # # External URL of the site https://example.com(:port if not 443)
 

--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ LOG_LEVEL=debug
 # Example: docker run --rm ghcr.io/dyrector-io/dyrectorio/cli/dyo:latest generate crux encryption-key
 ENCRYPTION_SECRET_KEY=Random_Generate_Key
 
-# # Database passwords and infos
+# # Database passwords
 
 # This value is the password to crux's database
 CRUX_POSTGRES_PASSWORD=Random_Generated_String

--- a/.github/workflows/builder_image_multidb.yaml
+++ b/.github/workflows/builder_image_multidb.yaml
@@ -1,0 +1,76 @@
+name: builder_image_multidb
+on:
+  push:
+    branches: [develop]
+    paths: [distribution/images/multi-db/**, .github/workflows/builder_image_multidb.yml]
+  pull_request:
+    paths: [distribution/images/multi-db/**, .github/workflows/builder_image_multidb.yml]
+permissions:
+  contents: read
+  pull-requests: read
+  packages: write
+env:
+  GITHUB_REGISTRY: ghcr.io
+  BUILDER_IMAGE_NAME: dyrector-io/dyrectorio/multi-database
+  VERSION: 1.0.0
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    environment: Workflow - Protected
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+      - name: Docker build
+        uses: docker/build-push-action@v3
+        with:
+          context: ./distribution/images/multi-db/
+          push: true
+          tags: ${{env.GITHUB_REGISTRY}}/${{env.BUILDER_IMAGE_NAME}}:${{env.VERSION}}
+      - name: Docker export image
+        run: |
+          docker save ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION} | gzip -f > builder.zstd
+      - name: Artifact upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: builder
+          path: ./builder.zstd
+  push:
+    runs-on: ubuntu-22.04
+    needs: build
+    if: github.ref_name == 'develop'
+    environment: Workflow - Protected
+    steps:
+      - name: Artifact download
+        uses: actions/download-artifact@v4
+        with:
+          name: builder
+          path: artifacts
+      - name: Add requirements
+        run: |
+          sudo apt update
+          sudo apt install zstd golang docker.io containerd runc
+          go install github.com/sigstore/cosign/v2/cmd/cosign@v2.0.2
+      - name: Load docker image
+        run: |
+          zcat artifacts/builder.zstd | docker load
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+      - name: Docker push
+        run: docker push ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION}
+      - name: Write signing key to disk
+        run: echo "${{ secrets.COSIGN_PRIVATE_KEY }}" > cosign.key
+      - name: Sign container image
+        run: |
+          ~/go/bin/cosign sign --yes --key cosign.key $(docker inspect --format='{{index .RepoDigests 0}}' ${GITHUB_REGISTRY}/${BUILDER_IMAGE_NAME}:${VERSION} )
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/distribution/images/multi-db/.env.example
+++ b/distribution/images/multi-db/.env.example
@@ -1,0 +1,3 @@
+POSTGRES_ROOT_PASSWORD="Random_Generated_String"
+CRUX_POSTGRES_PASSWORD="Random_Generated_String"
+KRATOS_POSTGRES_PASSWORD="Random_Generated_String"

--- a/distribution/images/multi-db/Dockerfile
+++ b/distribution/images/multi-db/Dockerfile
@@ -1,0 +1,11 @@
+FROM postgres:17.4-alpine
+
+COPY init-database.sh /docker-entrypoint-initdb.d/
+
+ENV POSTGRES_USER=root
+ENV CRUX_POSTGRES=crux
+ENV CRUX_POSTGRES_USER=crux_user
+ENV KRATOS_POSTGRES=kratos
+ENV KRATOS_POSTGRES_USER=kratos_user
+
+RUN chmod +x /docker-entrypoint-initdb.d/init-database.sh

--- a/distribution/images/multi-db/docker-compose.yml
+++ b/distribution/images/multi-db/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: ghcr.io/dyrector-io/dyrectorio/multi-database:1.2.3
+    image: ghcr.io/dyrector-io/dyrectorio/multi-database:1.0.0
     container_name: database
     restart: unless-stopped
     healthcheck:

--- a/distribution/images/multi-db/docker-compose.yml
+++ b/distribution/images/multi-db/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  database:
+    image: ghcr.io/dyrector-io/dyrectorio/multi-database:1.2.3
+    container_name: database
+    restart: unless-stopped
+    healthcheck:
+      test: [CMD-SHELL, pg_isready -d crux -U crux_user]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    labels:
+      - org.dyrectorio.service-category=_internal
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_ROOT_PASSWORD}
+      - CRUX_POSTGRES_PASSWORD=${CRUX_POSTGRES_PASSWORD}
+      - KRATOS_POSTGRES_PASSWORD=${KRATOS_POSTGRES_PASSWORD}
+    ports:
+      - "5432:5432"
+    volumes:
+      - database_data:/var/lib/postgresql/data
+      - ./init-database.sh:/docker-entrypoint-initdb.d/init-database.sh
+volumes:
+  database_data:

--- a/distribution/images/multi-db/init-database.sh
+++ b/distribution/images/multi-db/init-database.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Wait for PostgreSQL to start
-until pg_isready -U "root"; do
+until pg_isready -U "${POSTGRES_USER}"; do
   echo "Waiting for PostgreSQL to start..."
   sleep 2
 done
@@ -10,16 +10,16 @@ done
 # Create the database and users dynamically
 echo "Creating databases and users..."
 
-psql -v ON_ERROR_STOP=1 --username root <<-EOSQL
-  CREATE USER crux_user WITH ENCRYPTED PASSWORD '${CRUX_POSTGRES_PASSWORD}';
-  CREATE DATABASE crux;
-  GRANT ALL PRIVILEGES ON DATABASE crux TO crux_user;
-  ALTER DATABASE crux OWNER TO crux_user;
+psql -v ON_ERROR_STOP=1 --username '${POSTGRES_USER}' <<-EOSQL
+  CREATE USER '${CRUX_POSTGRES_USER}' WITH ENCRYPTED PASSWORD '${CRUX_POSTGRES_PASSWORD}';
+  CREATE DATABASE '${CRUX_POSTGRES}';
+  GRANT ALL PRIVILEGES ON DATABASE '${CRUX_POSTGRES}' TO '${CRUX_POSTGRES_USER}';
+  ALTER DATABASE '${CRUX_POSTGRES}' OWNER TO '${CRUX_POSTGRES_USER}';
 
-  CREATE USER kratos_user WITH ENCRYPTED PASSWORD '${KRATOS_POSTGRES_PASSWORD}';
-  CREATE DATABASE kratos;
-  GRANT ALL PRIVILEGES ON DATABASE kratos TO kratos_user;
-  ALTER DATABASE kratos OWNER TO kratos_user;
+  CREATE USER '${KRATOS_POSTGRES_USER}' WITH ENCRYPTED PASSWORD '${KRATOS_POSTGRES_PASSWORD}';
+  CREATE DATABASE '${KRATOS_POSTGRES}' ;
+  GRANT ALL PRIVILEGES ON DATABASE '${KRATOS_POSTGRES}'  TO '${KRATOS_POSTGRES_USER}';
+  ALTER DATABASE '${KRATOS_POSTGRES}' OWNER TO '${KRATOS_POSTGRES_USER}';
 EOSQL
 
 echo "Databases and users created successfully."

--- a/distribution/images/multi-db/init-database.sh
+++ b/distribution/images/multi-db/init-database.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eu
+
+# Wait for PostgreSQL to start
+until pg_isready -U "root"; do
+  echo "Waiting for PostgreSQL to start..."
+  sleep 2
+done
+
+# Create the database and users dynamically
+echo "Creating databases and users..."
+
+psql -v ON_ERROR_STOP=1 --username root <<-EOSQL
+  CREATE USER crux_user WITH ENCRYPTED PASSWORD '${CRUX_POSTGRES_PASSWORD}';
+  CREATE DATABASE crux;
+  GRANT ALL PRIVILEGES ON DATABASE crux TO crux_user;
+  ALTER DATABASE crux OWNER TO crux_user;
+
+  CREATE USER kratos_user WITH ENCRYPTED PASSWORD '${KRATOS_POSTGRES_PASSWORD}';
+  CREATE DATABASE kratos;
+  GRANT ALL PRIVILEGES ON DATABASE kratos TO kratos_user;
+  ALTER DATABASE kratos OWNER TO kratos_user;
+EOSQL
+
+echo "Databases and users created successfully."

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,23 @@
 # This is a minimal compose file, meant to be extended using files from the distribution/compose folder
 # Consult the GETTING_STARTED.md
 services:
+  database:
+    container_name: database
+    image: ghcr.io/dyrector-io/dyrectorio/multi-database:1.0.0
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_ROOT_PASSWORD}
+      - CRUX_POSTGRES_PASSWORD=${CRUX_POSTGRES_PASSWORD}
+      - KRATOS_POSTGRES_PASSWORD=${KRATOS_POSTGRES_PASSWORD}
+    restart: unless-stopped
+    volumes: ['database:/var/lib/postgresql/data']
+    healthcheck:
+      # testing the healtheck with a specific database and users
+      test: [CMD-SHELL, pg_isready -d crux -U crux_user]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    labels:
+      - org.dyrectorio.service-category=_internal
   crux:
     container_name: crux
     image: ghcr.io/dyrector-io/dyrectorio/web/crux:${DYO_VERSION:-stable}
@@ -8,7 +25,7 @@ services:
     environment:
       - TZ=${TIMEZONE:-UTC}
       - LOG_LEVEL=${LOG_LEVEL:-debug}
-      - DATABASE_URL=postgresql://crux:${CRUX_POSTGRES_PASSWORD}@crux-postgres:5432/crux?schema=public
+      - DATABASE_URL=postgresql://crux_user:${CRUX_POSTGRES_PASSWORD}@database:5432/crux?schema=public
       - KRATOS_ADMIN_URL=http://kratos:4434
       - KRATOS_URL=http://kratos:4433
       - CRUX_UI_URL=${EXTERNAL_PROTO}://${DOMAIN}${EXTERNAL_PORT}
@@ -24,7 +41,7 @@ services:
       - QA_OPT_OUT=${QA_OPT_OUT:-false}
       - ENCRYPTION_SECRET_KEY=${ENCRYPTION_SECRET_KEY}
     depends_on:
-      crux-postgres:
+      database:
         condition: service_healthy
       crux-migrate:
         condition: service_completed_successfully
@@ -39,27 +56,11 @@ services:
     command: [migrate]
     environment:
       - TZ=${TIMEZONE:-UTC}
-      - DATABASE_URL=postgresql://crux:${CRUX_POSTGRES_PASSWORD}@crux-postgres:5432/crux?schema=public&connect_timeout=5
+      - DATABASE_URL=postgresql://crux_user:${CRUX_POSTGRES_PASSWORD}@database:5432/crux?schema=public&connect_timeout=5
     depends_on:
-      crux-postgres:
+      database:
         condition: service_healthy
     restart: 'no'
-    labels:
-      - org.dyrectorio.service-category=_internal
-  crux-postgres:
-    container_name: crux-postgres
-    image: docker.io/library/postgres:13-alpine
-    environment:
-      - POSTGRES_PASSWORD=${CRUX_POSTGRES_PASSWORD}
-      - POSTGRES_USER=crux
-      - POSTGRES_DB=crux
-    restart: unless-stopped
-    volumes: ['crux-db:/var/lib/postgresql/data']
-    healthcheck:
-      test: [CMD-SHELL, pg_isready -U crux]
-      interval: 5s
-      timeout: 5s
-      retries: 5
     labels:
       - org.dyrectorio.service-category=_internal
   crux-ui:
@@ -85,7 +86,7 @@ services:
     image: ghcr.io/dyrector-io/dyrectorio/web/kratos:${DYO_VERSION:-stable}
     environment:
       - SQA_OPT_OUT=true
-      - DSN=postgres://kratos:${KRATOS_POSTGRES_PASSWORD}@kratos-postgres:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4&connect_timeout=5
+      - DSN=postgres://kratos_user:${KRATOS_POSTGRES_PASSWORD}@database:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4&connect_timeout=5
       - KRATOS_URL=${EXTERNAL_PROTO}://${DOMAIN}${EXTERNAL_PORT}/kratos
       - KRATOS_ADMIN_URL=http://kratos:4434
       - AUTH_URL=${EXTERNAL_PROTO}://${DOMAIN}${EXTERNAL_PORT}/auth
@@ -97,7 +98,7 @@ services:
       - FROM_EMAIL=${FROM_EMAIL}
       - FROM_NAME=${FROM_NAME}
     depends_on:
-      kratos-postgres:
+      database:
         condition: service_healthy
       kratos-migrate:
         condition: service_completed_successfully
@@ -110,29 +111,12 @@ services:
     command: -c /etc/config/kratos/kratos.yaml migrate sql -e --yes
     environment:
       - SQA_OPT_OUT=true
-      - DSN=postgres://kratos:${KRATOS_POSTGRES_PASSWORD}@kratos-postgres:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
+      - DSN=postgres://kratos_user:${KRATOS_POSTGRES_PASSWORD}@database:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
     depends_on:
-      kratos-postgres:
+      database:
         condition: service_healthy
     restart: 'no'
     labels:
       - org.dyrectorio.service-category=_internal
-  kratos-postgres:
-    container_name: kratos-postgres
-    image: docker.io/library/postgres:13-alpine
-    environment:
-      - POSTGRES_PASSWORD=${KRATOS_POSTGRES_PASSWORD}
-      - POSTGRES_USER=kratos
-      - POSTGRES_DB=kratos
-    restart: unless-stopped
-    volumes: ['kratos-db:/var/lib/postgresql/data']
-    healthcheck:
-      test: [CMD-SHELL, pg_isready -U kratos]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    labels:
-      - org.dyrectorio.service-category=_internal
 volumes:
-  crux-db:
-  kratos-db:
+  database:

--- a/web/crux/.env.example
+++ b/web/crux/.env.example
@@ -10,6 +10,9 @@ KRATOS_ADMIN_URL=http://localhost:4434
 DATABASE_URL="postgresql://username:password@localhost:5432/crux?schema=public"
 CRUX_UI_URL=http://localhost:8000
 
+
+CRUX_POSTGRES_PASSWORD="Random_Generated_String"
+
 # # Port settings
 
 # Agent gRPC API port
@@ -71,7 +74,6 @@ AGENT_CALLBACK_TIMEOUT=5000
 # MAX_GRPC_RECEIVE_MESSAGE_LENGTH=4194304
 
 # GRPC Timeout values and their respective defaults
-# 
 # GRPC_KEEPALIVE_TIMEOUT_MS=5000
 # GRPC_KEEPALIVE_TIME_MS=30000
 # HTTP2_MINPINGINTERVAL_MS=30000

--- a/web/crux/docker-compose.yaml
+++ b/web/crux/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     platform: linux/amd64
     environment:
       - TZ=UTC
-      - DATABASE_URL=postgresql://crux:${POSTGRES_PASSWORD}@crux-postgres:5432/crux?schema=public
+      - DATABASE_URL=postgresql://crux_user:${CRUX_POSTGRES_PASSWORD}@database:5432/crux?schema=public
     command: migrate
     networks:
       - crux-intranet
@@ -25,13 +25,13 @@ services:
       - 5001:5001
     environment:
       - TZ=UTC
-      - DATABASE_URL=postgresql://crux:${POSTGRES_PASSWORD}@crux-postgres:5432/crux?schema=public
-      - SMTP_URI=$SMTP_URI
-      - FROM_EMAIL=$FROM_EMAIL
-      - FROM_NAME=$FROM_NAME
-      - KRATOS_ADMIN_URL=$KRATOS_ADMIN_URL
-      - CRUX_UI_URL=$CRUX_UI_URL
-      - CRUX_AGENT_ADDRESS=$CRUX_AGENT_ADDRESS
+      - DATABASE_URL=postgresql://crux_user:${CRUX_POSTGRES_PASSWORD}@database:5432/crux?schema=public
+      - SMTP_URI=${SMTP_URI}
+      - FROM_EMAIL=${FROM_EMAIL}
+      - FROM_NAME=${FROM_NAME}
+      - KRATOS_ADMIN_URL=${KRATOS_ADMIN_URL}
+      - CRUX_UI_URL=${CRUX_UI_URL}
+      - CRUX_AGENT_ADDRESS=${CRUX_AGENT_ADDRESS}
     restart: unless-stopped
     command: serve
     networks:


### PR DESCRIPTION
We had two PostgreSQL instances instead of one. This PR merges them into a single instance and refactors the `docker-compose.yaml` files accordingly.  

I skipped the `cli` refactor because, after discussing with the internal team, we decided to use `docker compose` instead of the `CLI`. 