### PR TITLE
refactor(cli): avoid compose file duplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ cli:
 # Run the interactive compose-file config generator
 .PHONY: compose-init
 compose-init:
-	cd golang && make init-cli
+	cd golang
 	go run ./golang/cmd/dyo/main.go  generate compose --compose-dir "distribution/compose"
 
 # Create dyrector.io offline installer bundle

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -78,7 +78,7 @@ go-dagent:
 	air --build.cmd "" --build.bin "cd cmd/dagent && ${GRPC_DEBUG_FLAGS} go run ."
 
 .PHONY: cli
-cli: init-cli
+cli:
 	cd cmd/dyo && \
 	go run .
 
@@ -94,13 +94,8 @@ single-arch-check:
 		$(error Only one single architecture should be used. Use 'GOARCHS=<target-arch> make target')
 	endif
 
-.PHONY: init-cli
-init-cli:
-	cp -f ../distribution/compose/*.yaml pkg/cli/setup/files/
-	cp -f ../docker-compose.yaml pkg/cli/setup/files/
-
 .PHONY: compile-cli
-compile-cli: init-cli
+compile-cli:
 	cd cmd/dyo && \
 	$(foreach arch, $(GOARCHS), $(foreach os, $(GOOS), ${GOPARAMS} GOARCH=$(arch) GOOS=${os} go build ${LDFLAGS} -o ../../build/out/dyo-${os}-${arch}${OUT_EXT};))
 
@@ -135,12 +130,12 @@ compile-agents: compile-crane compile-dagent
 
 # running gosec for static code analysis for bugs and leaks
 .PHONY: security
-security: init-cli
+security:
 	gosec -severity high ./...
 
 # golangci for linting
 .PHONY: lint
-lint: init-cli
+lint:
 	golangci-lint run -c ../.golangci.yml ./...
 
 .PHONY: build-cli
@@ -259,16 +254,16 @@ k3d-rm:
 
 # dependency: valid & working k8s configuration
 .PHONY: test-unit
-test-unit: init-cli
+test-unit:
 	go test -tags=unit -race ./...
 
 # dependency: valid & working k8s configuration
 .PHONY: test-unit-with-coverage
-test-unit-with-coverage: init-cli
+test-unit-with-coverage:
 	go test -tags=unit -race -coverpkg=./... -coverprofile=./unit.cov -covermode=atomic ./...
 
 .PHONY: test-integration
-test-integration: init-cli test-dagent test-crane test-cli test-internal
+test-integration: test-dagent test-crane test-cli test-internal
 
 .PHONY: test-crane
 test-crane:

--- a/golang/pkg/cli/.gitignore
+++ b/golang/pkg/cli/.gitignore
@@ -1,1 +1,0 @@
-docker-compose.*

--- a/golang/pkg/cli/setup/setup.go
+++ b/golang/pkg/cli/setup/setup.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"bufio"
 	"crypto/rand"
-	_ "embed"
 	"fmt"
 	"net"
 	"os"
@@ -19,6 +18,7 @@ import (
 	ucli "github.com/urfave/cli/v2"
 	"golang.org/x/term"
 
+	reporoot "github.com/dyrector-io/dyrectorio"
 	"github.com/dyrector-io/dyrectorio/golang/internal/util"
 )
 
@@ -30,24 +30,6 @@ const (
 	defaultSecretLength = 32
 	cruxSecretLength    = 43
 )
-
-//go:embed files/docker-compose.yaml
-var composeBase []byte
-
-//go:embed files/docker-compose.traefik.yaml
-var traefikCompose []byte
-
-//go:embed files/docker-compose.traefik-tls.yaml
-var traefikTLSCompose []byte
-
-//go:embed files/docker-compose.traefik-labels.yaml
-var traefikLabelsCompose []byte
-
-//go:embed files/docker-compose.traefik-labels-tls.yaml
-var traefikLabelsTLSCompose []byte
-
-//go:embed files/docker-compose.mail-test.yaml
-var mailCompose []byte
 
 const (
 	FlagNoCompose              = "no-compose"
@@ -263,14 +245,14 @@ func (c ComposeItems) WriteToDisk() error {
 func GetItems(composeFolder string, deployTestMail, deployTraefik, addTraefikLabels, tls bool) ComposeItems {
 	items := []ComposeItem{{
 		Path:    "docker-compose.yaml",
-		Content: composeBase,
+		Content: reporoot.ComposeBase,
 	}}
 
 	if deployTestMail {
 		items = append(items,
 			ComposeItem{
 				Path:    filepath.Join(composeFolder, "docker-compose.mail-test.yaml"),
-				Content: mailCompose,
+				Content: reporoot.MailCompose,
 			})
 	}
 	if deployTraefik {
@@ -278,13 +260,13 @@ func GetItems(composeFolder string, deployTestMail, deployTraefik, addTraefikLab
 			items = append(items,
 				ComposeItem{
 					Path:    filepath.Join(composeFolder, "docker-compose.traefik-tls.yaml"),
-					Content: traefikTLSCompose,
+					Content: reporoot.TraefikTLSCompose,
 				})
 		} else {
 			items = append(items,
 				ComposeItem{
 					Path:    filepath.Join(composeFolder, "docker-compose.traefik.yaml"),
-					Content: traefikCompose,
+					Content: reporoot.TraefikCompose,
 				})
 		}
 	}
@@ -292,13 +274,13 @@ func GetItems(composeFolder string, deployTestMail, deployTraefik, addTraefikLab
 		items = append(items,
 			ComposeItem{
 				Path:    filepath.Join(composeFolder, "docker-compose.traefik-labels.yaml"),
-				Content: traefikLabelsCompose,
+				Content: reporoot.TraefikLabelsCompose,
 			})
 		if tls {
 			items = append(items,
 				ComposeItem{
 					Path:    filepath.Join(composeFolder, "docker-compose.traefik-labels-tls.yaml"),
-					Content: traefikLabelsTLSCompose,
+					Content: reporoot.TraefikLabelsTLSCompose,
 				})
 		}
 	}

--- a/repo_root.go
+++ b/repo_root.go
@@ -1,0 +1,26 @@
+/*
+Serves as a proxy for other packages allowing these files to be imported from repo root
+*/
+package reporoot
+
+import (
+	_ "embed"
+)
+
+//go:embed docker-compose.yaml
+var ComposeBase []byte
+
+//go:embed distribution/compose/docker-compose.traefik.yaml
+var TraefikCompose []byte
+
+//go:embed distribution/compose/docker-compose.traefik-tls.yaml
+var TraefikTLSCompose []byte
+
+//go:embed distribution/compose/docker-compose.traefik-labels.yaml
+var TraefikLabelsCompose []byte
+
+//go:embed distribution/compose/docker-compose.traefik-labels-tls.yaml
+var TraefikLabelsTLSCompose []byte
+
+//go:embed distribution/compose/docker-compose.mail-test.yaml
+var MailCompose []byte


### PR DESCRIPTION
Duplicated off-tree compose files caused issues and it's not particularly neat. This is a proposal of an alternative solution to avoid duplication.