### PR TITLE
fix(web): bundle secret key duplication

### DIFF
--- a/web/crux/src/domain/container-merge.ts
+++ b/web/crux/src/domain/container-merge.ts
@@ -82,16 +82,17 @@ export const mergeMarkers = (strong: Marker, weak: Marker): Marker => {
   }
 }
 
-const mergeSecretKeys = (one: UniqueSecretKey[], other: UniqueSecretKey[]): UniqueSecretKey[] => {
-  if (!one) {
-    return other
+const mergeUniqueKeys = <T extends UniqueKey>(strong: T[], weak: T[]): T[] => {
+  if (!strong) {
+    return weak ?? null
   }
 
-  if (!other) {
-    return one
+  if (!weak) {
+    return strong
   }
 
-  return [...one, ...other.filter(it => !one.includes(it))]
+  const missing = weak.filter(w => !strong.find(it => it.key === w.key))
+  return [...strong, ...missing]
 }
 
 export const mapSecretKeyToSecretKeyValue = (secret: UniqueSecretKey): UniqueSecretKeyValue => ({
@@ -114,7 +115,7 @@ export const mergeSecrets = (strong: UniqueSecretKeyValue[], weak: UniqueSecretK
 
   const overriddenKeys: Set<string> = new Set(strong.map(it => it.key))
 
-  // removes non required secrets, when they are not present in the concrete config
+  // remove non required secrets, when they are not present in the concrete config
   const missing: UniqueSecretKeyValue[] = weak
     .filter(it => !overriddenKeys.has(it.key) && it.required)
     .map(it => mapSecretKeyToSecretKeyValue(it))
@@ -126,7 +127,7 @@ const mergeConfigs = (strong: ContainerConfigData, weak: ContainerConfigData): C
   // common
   name: strong.name ?? weak.name,
   environment: strong.environment ?? weak.environment,
-  secrets: mergeSecretKeys(strong.secrets, weak.secrets),
+  secrets: mergeUniqueKeys(strong.secrets, weak.secrets),
   user: mergeNumber(strong.user, weak.user),
   workingDirectory: strong.workingDirectory ?? weak.workingDirectory,
   tty: mergeBoolean(strong.tty, weak.tty),
@@ -180,19 +181,6 @@ export const mergeConfigsWithConcreteConfig = (
     ...baseConfig,
     secrets: mergeSecrets(concrete.secrets, squashed.secrets),
   }
-}
-
-const mergeUniqueKeys = <T extends UniqueKey>(strong: T[], weak: T[]): T[] => {
-  if (!strong) {
-    return weak ?? null
-  }
-
-  if (!weak) {
-    return strong
-  }
-
-  const missing = weak.filter(w => !strong.find(it => it.key === w.key))
-  return [...strong, ...missing]
 }
 
 const mergeUniqueKeyValues = <T extends UniqueKeyValue>(strong: T[], weak: T[]): T[] => {


### PR DESCRIPTION
Fixes a bug where there was no option to resolve  a secret value, when its key was present in multiple config bundles