### PR TITLE
fix(crane): RBAC, reorganize APIs and add missing roles

### DIFF
--- a/web/crux/assets/install-script/install-k8s.sh.hbr
+++ b/web/crux/assets/install-script/install-k8s.sh.hbr
@@ -45,18 +45,13 @@ metadata:
   labels:
     rbac.dyrector.io/crane: "restricted-api-access"
 rules:
--
-  apiGroups:
-  - apps
-  - ""
-  - "monitoring.coreos.com"
+- apiGroups: [""]
   resources:
   - deployments
   - services
   - pods
   - ingress
   - secrets
-  - servicemonitors
   - configmaps
   - events
   - namespaces
@@ -69,6 +64,43 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["networking.k8s.io"]
+  resources:
+    - ingresses
+  verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups: ["apps"]
+  resources:
+    - deployments
+    - replicasets
+  verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+    - servicemonitors
+  verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
On a fresh cluster the roles were insufficient to manage objects that crane uses.
Here is the fix.