### PR TITLE
feat(crux-ui): add confirmation dialog for redeploying deployments with successful status

### DIFF
--- a/web/crux-ui/locales/en/common.json
+++ b/web/crux-ui/locales/en/common.json
@@ -251,6 +251,11 @@
     "description": "There is a protected deployment with the same node and prefix. Continuing the deployment could result in unexpected behaviour. Are you sure want to continue?"
   },
 
+  "deployConfirm": {
+    "title": "Are you sure?",
+    "description": "Are you sure you want to deploy again a {{status}} deployment?"
+  },
+
   "imageConfig": "Image config",
   "instanceConfig": "Instance config",
   "deploymentConfig": "Deployment config"

--- a/web/crux-ui/quality-assurance.ts
+++ b/web/crux-ui/quality-assurance.ts
@@ -105,6 +105,7 @@ export const QA_DIALOG_LABEL_CHANGE_TEAM_SLUG = 'changeTeamSlug'
 export const QA_DIALOG_LABEL_LEAVE_TEAM = 'leaveTeam'
 export const QA_DIALOG_LABEL_UPDATE_USER_ROLE = 'updateUserRole'
 export const QA_DIALOG_LABEL_DEPLOY_PROTECTED = 'deployProtected'
+export const QA_DIALOG_LABEL_DEPLOY_CONFIRM = "deployConfirm"
 export const QA_DIALOG_LABEL_HIDE_ONBOARDING = 'hideOnboarding'
 export const QA_DIALOG_LABEL_CONVERT_PROJECT_TO_VERSIONED = ''
 export const QA_DIALOG_LABEL_REMOVE_OIDC_ACCOUNT = 'removeOIDCAccount'

--- a/web/crux-ui/src/hooks/use-deploy.ts
+++ b/web/crux-ui/src/hooks/use-deploy.ts
@@ -1,5 +1,11 @@
 import { defaultApiErrorHandler } from '@app/errors'
-import { DeploymentDetails, DyoApiError, mergeConfigsWithConcreteConfig, StartDeployment } from '@app/models'
+import {
+  DeploymentDetails,
+  deploymentShouldBeConfirmed,
+  DyoApiError,
+  mergeConfigsWithConcreteConfig,
+  StartDeployment,
+} from '@app/models'
 import { TeamRoutes } from '@app/routes'
 import { sendForm } from '@app/utils'
 import {
@@ -11,7 +17,7 @@ import {
 import { Translate } from 'next-translate'
 import useTranslation from 'next-translate/useTranslation'
 import { NextRouter } from 'next/router'
-import { QA_DIALOG_LABEL_DEPLOY_PROTECTED } from 'quality-assurance'
+import { QA_DIALOG_LABEL_DEPLOY_CONFIRM, QA_DIALOG_LABEL_DEPLOY_PROTECTED } from 'quality-assurance'
 import toast from 'react-hot-toast'
 import { DyoConfirmationAction } from './use-confirmation'
 
@@ -83,6 +89,20 @@ export const useDeploy = (opts: UseDeployOptions): UseDeployAction => {
             className: toastClassName,
           },
         )
+        return
+      }
+    }
+
+    if (deploymentShouldBeConfirmed(deployment.status)) {
+      const confirmed = await confirm({
+        qaLabel: QA_DIALOG_LABEL_DEPLOY_CONFIRM,
+        title: t('common:deployConfirm.title'),
+        description: t('common:deployConfirm.description', deployment),
+        confirmText: t('common:deploy'),
+        cancelColor: 'bg-warning-orange',
+      })
+
+      if (!confirmed) {
         return
       }
     }

--- a/web/crux-ui/src/models/common.ts
+++ b/web/crux-ui/src/models/common.ts
@@ -16,7 +16,14 @@ export type DyoApiError = DyoErrorDto & {
 
 // deployment
 
-export const DEPLOYMENT_STATUS_VALUES = ['preparing', 'in-progress', 'successful', 'failed', 'obsolete'] as const
+export const DEPLOYMENT_STATUS_VALUES = [
+  'preparing',
+  'in-progress',
+  'successful',
+  'failed',
+  'obsolete',
+  'downgraded',
+] as const
 export type DeploymentStatus = (typeof DEPLOYMENT_STATUS_VALUES)[number]
 
 // ws

--- a/web/crux-ui/src/models/deployment.ts
+++ b/web/crux-ui/src/models/deployment.ts
@@ -203,6 +203,18 @@ export const deploymentIsDeployable = (status: DeploymentStatus): boolean => {
     case 'preparing':
     case 'failed':
     case 'obsolete':
+    case 'downgraded':
+    case 'successful':
+      return true
+    default:
+      return false
+  }
+}
+
+export const deploymentShouldBeConfirmed = (status: DeploymentStatus) => {
+  switch (status) {
+    case 'downgraded':
+    case 'obsolete':
     case 'successful':
       return true
     default:


### PR DESCRIPTION
Add confirmation dialog for deployments with successful, downgrade or obsolete status.