### PR TITLE
fix: update selector in e2e/without-login test

### DIFF
--- a/web/crux-ui/e2e/without-login/login.spec.ts
+++ b/web/crux-ui/e2e/without-login/login.spec.ts
@@ -46,7 +46,7 @@ test('sign up navigates to the register page', async ({ page }) => {
 test('recovery navigates to the recovery page', async ({ page }) => {
   await page.goto(ROUTE_LOGIN)
 
-  await page.locator('"Recovery"').click()
+  await page.locator('"Forgot your password?"').click()
 
   await expect(page).toHaveURL('/auth/recovery')
   await expect(page.locator('h1')).toContainText('Account recovery')


### PR DESCRIPTION
The Playwright test in e2e/without-login was failing due to an outdated selector.
Updated the selector to match the current UI, and the test now passes ✅
Let me know if any additional changes are needed.