### PR TITLE
feat: version ordering

### DIFF
--- a/web/crux-ui/src/components/projects/project-versions-section.tsx
+++ b/web/crux-ui/src/components/projects/project-versions-section.tsx
@@ -1,5 +1,6 @@
 import { DyoHeading } from '@app/elements/dyo-heading'
 import { DyoConfirmationModal } from '@app/elements/dyo-modal'
+import { sortDate } from '@app/elements/dyo-table'
 import DyoWrap from '@app/elements/dyo-wrap'
 import useConfirmation from '@app/hooks/use-confirmation'
 import { Version } from '@app/models'
@@ -7,7 +8,19 @@ import useTranslation from 'next-translate/useTranslation'
 import { QA_DIALOG_LABEL_SET_AS_DEFAULT } from 'quality-assurance'
 import VersionCard from './versions/version-card'
 
-interface ProjectVersionsSectionProps {
+const sortVersions = (one: Version, other: Version) => {
+  if (one.default) {
+    return -1
+  }
+
+  if (other.default) {
+    return 1
+  }
+
+  return sortDate(one.audit.updatedAt, other.audit.updatedAt)
+}
+
+type ProjectVersionsSectionProps = {
   projectId: string
   versions: Version[]
   onIncrease?: (version: Version) => void
@@ -35,6 +48,8 @@ const ProjectVersionsSection = (props: ProjectVersionsSectionProps) => {
 
     onSetAsDefault(version)
   }
+
+  versions.sort(sortVersions)
 
   return versions.length ? (
     <>

--- a/web/crux/src/app/version/version.service.ts
+++ b/web/crux/src/app/version/version.service.ts
@@ -408,27 +408,43 @@ export default class VersionService {
 
   async setDefaultVersion(projectId: string, versionId: string): Promise<void> {
     await this.prisma.$transaction(async prisma => {
+      const currentDefault = await prisma.version.findFirst({
+        where: {
+          projectId,
+          default: true,
+        },
+        select: {
+          id: true,
+          updatedAt: true,
+        },
+      })
+
+      const version = await prisma.version.findUnique({
+        where: {
+          id: versionId,
+        },
+        select: {
+          updatedAt: true,
+        },
+      })
+
+      await prisma.version.update({
+        where: {
+          id: currentDefault.id,
+        },
+        data: {
+          default: false,
+          updatedAt: currentDefault.updatedAt, // keep the original updatedAt
+        },
+      })
+
       await prisma.version.update({
         where: {
           id: versionId,
         },
         data: {
           default: true,
-        },
-        select: {
-          projectId: true,
-        },
-      })
-
-      await prisma.version.updateMany({
-        where: {
-          NOT: {
-            id: versionId,
-          },
-          projectId,
-        },
-        data: {
-          default: false,
+          updatedAt: version.updatedAt, // keep the original updatedAt
         },
       })
     })


### PR DESCRIPTION
- Order versions by their last modification date
- Show default versions as the first one in the version list
- Skip version modification date changes while changing default versions.