### PR TITLE
fix: instance config merge

### DIFF
--- a/web/crux-ui/e2e/utils/websocket-match.ts
+++ b/web/crux-ui/e2e/utils/websocket-match.ts
@@ -38,18 +38,20 @@ export const wsPatchMatchEverySecret =
     return secretKeys.every(it => payloadSecretKeys.includes(it))
   }
 
-export const wsPatchMatchNonNullSecretValues =
-  (secretKeys: string[]) =>
+export const wsPatchMatchSecrets =
+  (secrets: Record<string, string | null>) =>
   (payload: any): boolean => {
     const payloadSecrets: UniqueSecretKeyValue[] = payload.config?.secrets ?? []
 
-    return (
-      secretKeys.every(secKey => payloadSecrets.find(it => it.key === secKey)) &&
-      payloadSecrets.every(it => typeof it.value === 'string')
-    )
+    return Object.entries(secrets).some(entry => {
+      const [key, value] = entry
+
+      const payloadSecret = payloadSecrets.find(it => it.key === key)
+      return payloadSecret && payloadSecret.value === value
+    })
   }
 
-export const wsPatchMatchSecret = (secret: string, required: boolean) => (payload: any) =>
+export const wsPatchMatchSomeRequiredSecret = (secret: string, required: boolean) => (payload: any) =>
   payload.config?.secrets?.some(it => it.key === secret && it.required === required)
 
 export const wsPatchMatchCommand = (command: string) => (payload: any) =>

--- a/web/crux-ui/e2e/with-login/container-config/common-editor.spec.ts
+++ b/web/crux-ui/e2e/with-login/container-config/common-editor.spec.ts
@@ -13,7 +13,7 @@ import {
   wsPatchMatchPortRange,
   wsPatchMatchPorts,
   wsPatchMatchRouting,
-  wsPatchMatchSecret,
+  wsPatchMatchSomeRequiredSecret,
   wsPatchMatchStorage,
   wsPatchMatchTTY,
   wsPatchMatchUser,
@@ -207,7 +207,7 @@ test.describe('Image common config from editor', () => {
     const secret = 'secretName'
     const secretInput = page.locator('input[placeholder="Secrets"] >> visible=true').nth(0)
 
-    const wsSent = wsPatchSent(ws, wsRoute, WS_TYPE_PATCH_CONFIG, wsPatchMatchSecret(secret, true))
+    const wsSent = wsPatchSent(ws, wsRoute, WS_TYPE_PATCH_CONFIG, wsPatchMatchSomeRequiredSecret(secret, true))
     await secretInput.fill(secret)
 
     await page.getByRole('switch', { checked: false }).locator(':right-of(:text("Required"))').click()

--- a/web/crux-ui/e2e/with-login/container-config/common-json.spec.ts
+++ b/web/crux-ui/e2e/with-login/container-config/common-json.spec.ts
@@ -13,7 +13,7 @@ import {
   wsPatchMatchPortRange,
   wsPatchMatchPorts,
   wsPatchMatchRouting,
-  wsPatchMatchSecret,
+  wsPatchMatchSomeRequiredSecret,
   wsPatchMatchStorage,
   wsPatchMatchTTY,
   wsPatchMatchUser,
@@ -248,7 +248,7 @@ test.describe('Image common config from JSON', () => {
     const json = JSON.parse(await jsonEditor.inputValue())
     json.secrets = [{ key: secret, required: true }]
 
-    const wsSent = wsPatchSent(ws, wsRoute, WS_TYPE_PATCH_CONFIG, wsPatchMatchSecret(secret, true))
+    const wsSent = wsPatchSent(ws, wsRoute, WS_TYPE_PATCH_CONFIG, wsPatchMatchSomeRequiredSecret(secret, true))
     await jsonEditor.fill(JSON.stringify(json))
     await wsSent
 

--- a/web/crux-ui/e2e/with-login/deployment/deployment-copy.spec.ts
+++ b/web/crux-ui/e2e/with-login/deployment/deployment-copy.spec.ts
@@ -1,6 +1,6 @@
 import { WS_TYPE_PATCH_CONFIG } from '@app/models'
 import { Page, expect } from '@playwright/test'
-import { wsPatchMatchEverySecret, wsPatchMatchNonNullSecretValues } from 'e2e/utils/websocket-match'
+import { wsPatchMatchEverySecret, wsPatchMatchSecrets } from 'e2e/utils/websocket-match'
 import { DAGENT_NODE, NGINX_TEST_IMAGE_WITH_TAG, TEAM_ROUTES, waitForURLExcept } from '../../utils/common'
 import { createNode } from '../../utils/nodes'
 import {
@@ -55,7 +55,13 @@ test.describe('Deployment Copy', () => {
   let originalDeploymentId: string
   const secretKeys = ['secretOne', 'secretTwo']
   const newSecretKey = 'new-secret'
-  const newSecretKeyList = [...secretKeys, newSecretKey]
+  const newSecretValue = 'new-secret-value'
+
+  const mergedSecrets = {
+    secretOne: null,
+    secretTwo: null,
+    'new-secret': newSecretValue,
+  }
 
   // NOTE(@robot9706): beforeAll runs on each worker, so if tests are running in parallel beforeAll executes multiple times
   test.describe.configure({ mode: 'serial' })
@@ -85,8 +91,6 @@ test.describe('Deployment Copy', () => {
 
     const originalConfigId = await openInstanceConfigByDeploymentTable(page, 'nginx')
 
-    const newSecretValue = 'new-secret-value'
-
     const newSecretKeyInput = page.locator('input[placeholder="Key"][value=""]:below(label:has-text("SECRETS"))')
     await newSecretKeyInput.fill(newSecretKey)
 
@@ -96,7 +100,7 @@ test.describe('Deployment Copy', () => {
     await newSecretValueInput.fill(newSecretValue)
 
     const wsRoute = TEAM_ROUTES.containerConfig.detailsSocket(originalConfigId)
-    const wsSent = wsPatchSent(ws, wsRoute, WS_TYPE_PATCH_CONFIG, wsPatchMatchNonNullSecretValues(newSecretKeyList))
+    const wsSent = wsPatchSent(ws, wsRoute, WS_TYPE_PATCH_CONFIG, wsPatchMatchSecrets(mergedSecrets))
     await page.locator(`button:has-text("Save"):below(input[value="${newSecretValue}"])`).click()
     await wsSent
 

--- a/web/crux-ui/src/components/shared/secret-key-value-input.tsx
+++ b/web/crux-ui/src/components/shared/secret-key-value-input.tsx
@@ -152,7 +152,7 @@ const clearItem =
       return state
     }
 
-    item.value = ''
+    item.value = null
     item.encrypted = false
     item.publicKey = null
 
@@ -268,6 +268,15 @@ const SecretKeyValueInput = (props: SecretKeyValueInputProps) => {
       [...newItems].map(async (it): Promise<UniqueSecretKeyValue> => {
         let { value } = it
         let encryptedWithPublicKey = it.publicKey
+
+        if (!it.value) {
+          return {
+            ...it,
+            value: null,
+            encrypted: false,
+            publicKey: publicKey ?? null,
+          }
+        }
 
         if (!it.encrypted) {
           if (!publicKey) {

--- a/web/crux-ui/src/models/container-merge.ts
+++ b/web/crux-ui/src/models/container-merge.ts
@@ -144,14 +144,17 @@ const mergeObject = (strong: object, weak: object) => {
 
 export const mapSecretKeyToSecretKeyValue = (secret: UniqueSecretKey): UniqueSecretKeyValue => ({
   ...secret,
-  value: '',
+  value: null,
   encrypted: false,
   publicKey: null,
 })
 
-export const mergeSecrets = (strong: UniqueSecretKeyValue[], weak: UniqueSecretKey[]): UniqueSecretKeyValue[] => {
+export const mergeSecrets = (
+  strong: UniqueSecretKeyValue[],
+  weak: UniqueSecretKey[],
+): UniqueSecretKeyValue[] | null => {
   if (!weak) {
-    return strong ?? []
+    return strong ?? null
   }
 
   if (!strong) {

--- a/web/crux-ui/src/models/container-merge.ts
+++ b/web/crux-ui/src/models/container-merge.ts
@@ -272,12 +272,12 @@ export const mergeConfigsWithConcreteConfig = (
   }
 }
 
-export const mergeDeploymentConfigWithImageConfig = (
-  deployment: ConcreteContainerConfigData,
+export const mergeInstanceConfigWithImageConfig = (
+  instance: ConcreteContainerConfigData,
   image: ContainerConfigData,
 ): ConcreteContainerConfigData => ({
-  ...mergeConfigs(deployment, image),
-  secrets: mergeSecrets(deployment.secrets, image.secrets),
+  ...squashConfigs(instance, image),
+  secrets: mergeSecrets(instance.secrets, image.secrets),
 })
 
 export const mergeInstanceConfigWithDeploymentConfig = (
@@ -287,7 +287,6 @@ export const mergeInstanceConfigWithDeploymentConfig = (
   // common
   name: instance.name ?? deployment.name ?? null,
   environment: mergeUniqueKeyValues(instance.environment, deployment.environment),
-  secrets: mergeUniqueKeyValues(instance.secrets, deployment.secrets),
   user: mergeNumber(instance.user, deployment.user),
   workingDirectory: instance.workingDirectory ?? deployment.workingDirectory ?? null,
   tty: mergeBoolean(instance.tty, deployment.tty),
@@ -324,4 +323,5 @@ export const mergeInstanceConfigWithDeploymentConfig = (
   dockerLabels: mergeUniqueKeyValues(instance.dockerLabels, deployment.dockerLabels),
   expectedState: instance.expectedState ?? deployment.expectedState ?? null,
   experimental: mergeObject(instance.experimental, deployment.experimental),
+  secrets: mergeUniqueKeyValues(instance.secrets, deployment.secrets),
 })

--- a/web/crux/src/app/deploy/interceptors/deploy.start.interceptor.ts
+++ b/web/crux/src/app/deploy/interceptors/deploy.start.interceptor.ts
@@ -49,7 +49,7 @@ export default class DeployStartValidationInterceptor implements NestInterceptor
               },
             },
           },
-          where: !dto.instances
+          where: !dto?.instances
             ? undefined
             : {
                 id: {

--- a/web/crux/src/domain/container-merge.spec.ts
+++ b/web/crux/src/domain/container-merge.spec.ts
@@ -6,6 +6,46 @@ import {
   mergeInstanceConfigWithImageConfig,
 } from './container-merge'
 
+const emptyConfig: ConcreteContainerConfigData = {
+  annotations: null,
+  args: null,
+  capabilities: [],
+  commands: null,
+  configContainer: null,
+  corsHeaders: null,
+  deploymentStrategy: null,
+  dockerLabels: null,
+  environment: null,
+  expectedState: null,
+  experimental: null,
+  expose: null,
+  extraLBAnnotations: null,
+  healthCheckConfig: null,
+  initContainers: null,
+  labels: null,
+  logConfig: null,
+  metrics: null,
+  name: null,
+  networkMode: null,
+  networks: null,
+  portRanges: null,
+  ports: null,
+  proxyBuffering: null,
+  proxyHeaders: null,
+  resourceConfig: null,
+  restartPolicy: null,
+  routing: null,
+  secrets: null,
+  storageConfig: null,
+  storageId: null,
+  storageSet: false,
+  tty: null,
+  useLoadBalancer: null,
+  user: null,
+  volumes: null,
+  workingDirectory: null,
+}
+
 describe('container-merge', () => {
   const fullConfig: ContainerConfigData = {
     name: 'img',
@@ -755,7 +795,7 @@ describe('container-merge', () => {
             key: 'secret2',
             required: true,
             encrypted: false,
-            value: '',
+            value: null,
             publicKey: null,
           },
           ...fullConcreteConfig.secrets,
@@ -776,7 +816,7 @@ describe('container-merge', () => {
             key: 'secret1',
             required: false,
             encrypted: false,
-            value: '',
+            value: null,
             publicKey: null,
           },
           {
@@ -784,7 +824,7 @@ describe('container-merge', () => {
             key: 'secret2',
             required: true,
             encrypted: false,
-            value: '',
+            value: null,
             publicKey: null,
           },
         ],
@@ -833,7 +873,7 @@ describe('container-merge', () => {
             key: 'secret1',
             required: false,
             encrypted: false,
-            value: '',
+            value: null,
             publicKey: null,
           },
           {
@@ -841,13 +881,60 @@ describe('container-merge', () => {
             key: 'secret2',
             required: true,
             encrypted: false,
-            value: '',
+            value: null,
             publicKey: null,
           },
         ],
       }
 
       const merged = mergeConfigsWithConcreteConfig([fullConfig], concrete)
+
+      expect(merged).toEqual(expected)
+    })
+
+    it('should use the original secrets, when there are no overriden secrets', () => {
+      const base: ContainerConfigData = {
+        secrets: [
+          {
+            id: 'required',
+            key: 'required',
+            required: true,
+          },
+          {
+            id: 'non-required',
+            key: 'non-required',
+            required: false,
+          },
+        ],
+      }
+
+      const concrete: ConcreteContainerConfigData = {
+        secrets: null,
+      }
+
+      const merged = mergeConfigsWithConcreteConfig([base], concrete)
+
+      const expected: ConcreteContainerConfigData = {
+        ...emptyConfig,
+        secrets: [
+          {
+            id: 'required',
+            key: 'required',
+            value: null,
+            required: true,
+            encrypted: false,
+            publicKey: null,
+          },
+          {
+            id: 'non-required',
+            key: 'non-required',
+            value: null,
+            required: false,
+            encrypted: false,
+            publicKey: null,
+          },
+        ],
+      }
 
       expect(merged).toEqual(expected)
     })
@@ -873,7 +960,7 @@ describe('container-merge', () => {
             key: 'secret2',
             required: true,
             encrypted: false,
-            value: '',
+            value: null,
             publicKey: null,
           },
           ...fullConcreteConfig.secrets,

--- a/web/crux/src/domain/container-merge.spec.ts
+++ b/web/crux/src/domain/container-merge.spec.ts
@@ -1,5 +1,10 @@
 import { ConcreteContainerConfigData, ContainerConfigData } from './container'
-import { mergeConfigsWithConcreteConfig, mergeInstanceConfigWithDeploymentConfig } from './container-merge'
+import {
+  mapSecretKeyToSecretKeyValue,
+  mergeConfigsWithConcreteConfig,
+  mergeInstanceConfigWithDeploymentConfig,
+  mergeInstanceConfigWithImageConfig,
+} from './container-merge'
 
 describe('container-merge', () => {
   const fullConfig: ContainerConfigData = {
@@ -846,7 +851,57 @@ describe('container-merge', () => {
 
       expect(merged).toEqual(expected)
     })
+  })
 
+  describe('mergeInstanceConfigWithImageConfig', () => {
+    it('should remove overridden image config values, when overriding', () => {
+      const image: ContainerConfigData = {
+        ...fullConfig,
+      }
+
+      const instance: ConcreteContainerConfigData = {
+        ...fullConcreteConfig,
+      }
+
+      const merged = mergeInstanceConfigWithImageConfig(instance, image)
+
+      const expected: ConcreteContainerConfigData = {
+        ...fullConcreteConfig,
+        secrets: [
+          {
+            id: 'secret2',
+            key: 'secret2',
+            required: true,
+            encrypted: false,
+            value: '',
+            publicKey: null,
+          },
+          ...fullConcreteConfig.secrets,
+        ],
+      }
+
+      expect(merged).toEqual(expected)
+    })
+
+    it('should keep image config values, when not overriding', () => {
+      const image: ContainerConfigData = {
+        ...fullConfig,
+      }
+
+      const instance: ConcreteContainerConfigData = {}
+
+      const merged = mergeInstanceConfigWithImageConfig(instance, image)
+
+      const expected: ConcreteContainerConfigData = {
+        ...fullConfig,
+        secrets: fullConfig.secrets.map(it => mapSecretKeyToSecretKeyValue(it)),
+      }
+
+      expect(merged).toEqual(expected)
+    })
+  })
+
+  describe('mergeInstanceConfigWithDeploymentConfig', () => {
     it('should mix the instance config with the deployment config', () => {
       const instance: ConcreteContainerConfigData = {
         ...fullConcreteConfig,

--- a/web/crux/src/domain/container-merge.ts
+++ b/web/crux/src/domain/container-merge.ts
@@ -174,21 +174,22 @@ const mergeObject = (strong: object, weak: object) => {
 
 export const mapSecretKeyToSecretKeyValue = (secret: UniqueSecretKey): UniqueSecretKeyValue => ({
   ...secret,
-  value: '',
+  value: null,
   encrypted: false,
   publicKey: null,
 })
 
-export const mergeSecrets = (strong: UniqueSecretKeyValue[], weak: UniqueSecretKey[]): UniqueSecretKeyValue[] => {
+export const mergeSecrets = (
+  strong: UniqueSecretKeyValue[],
+  weak: UniqueSecretKey[],
+): UniqueSecretKeyValue[] | null => {
   if (!weak) {
-    return strong ?? []
+    return strong ?? null
   }
 
   if (!strong) {
     return weak.map(it => mapSecretKeyToSecretKeyValue(it))
   }
-  weak = weak ?? []
-  strong = strong ?? []
 
   const overriddenKeys: Set<string> = new Set(strong.map(it => it.key))
 

--- a/web/crux/src/domain/container-merge.ts
+++ b/web/crux/src/domain/container-merge.ts
@@ -304,12 +304,12 @@ export const mergeConfigsWithConcreteConfig = (
   }
 }
 
-export const mergeDeploymentConfigWithImageConfig = (
-  deployment: ConcreteContainerConfigData,
+export const mergeInstanceConfigWithImageConfig = (
+  instance: ConcreteContainerConfigData,
   image: ContainerConfigData,
 ): ConcreteContainerConfigData => ({
-  ...mergeConfigs(deployment, image),
-  secrets: mergeSecrets(deployment.secrets, image.secrets),
+  ...squashConfigs(instance, image),
+  secrets: mergeSecrets(instance.secrets, image.secrets),
 })
 
 export const mergeInstanceConfigWithDeploymentConfig = (
@@ -319,7 +319,6 @@ export const mergeInstanceConfigWithDeploymentConfig = (
   // common
   name: instance.name ?? deployment.name ?? null,
   environment: mergeUniqueKeyValues(instance.environment, deployment.environment),
-  secrets: mergeUniqueKeyValues(instance.secrets, deployment.secrets),
   user: mergeNumber(instance.user, deployment.user),
   workingDirectory: instance.workingDirectory ?? deployment.workingDirectory ?? null,
   tty: mergeBoolean(instance.tty, deployment.tty),
@@ -356,4 +355,5 @@ export const mergeInstanceConfigWithDeploymentConfig = (
   dockerLabels: mergeUniqueKeyValues(instance.dockerLabels, deployment.dockerLabels),
   expectedState: instance.expectedState ?? deployment.expectedState ?? null,
   experimental: mergeObject(instance.experimental, deployment.experimental),
+  secrets: mergeUniqueKeyValues(instance.secrets, deployment.secrets),
 })

--- a/web/crux/src/domain/start-deployment.spec.ts
+++ b/web/crux/src/domain/start-deployment.spec.ts
@@ -1,0 +1,214 @@
+import { ConcreteContainerConfigData } from './container'
+import {
+  DeployableConfigBundle,
+  DeployableDeployment,
+  DeployableImage,
+  DeployableInstance,
+  instanceConfigOf,
+} from './start-deployment'
+
+const emptyConfig: ConcreteContainerConfigData = {
+  annotations: null,
+  args: null,
+  capabilities: [],
+  commands: null,
+  configContainer: null,
+  corsHeaders: null,
+  deploymentStrategy: null,
+  dockerLabels: null,
+  environment: null,
+  expectedState: null,
+  experimental: null,
+  expose: null,
+  extraLBAnnotations: null,
+  healthCheckConfig: null,
+  initContainers: null,
+  labels: null,
+  logConfig: null,
+  metrics: null,
+  name: null,
+  networkMode: null,
+  networks: null,
+  portRanges: null,
+  ports: null,
+  proxyBuffering: null,
+  proxyHeaders: null,
+  resourceConfig: null,
+  restartPolicy: null,
+  routing: null,
+  secrets: null,
+  storageConfig: null,
+  storageId: null,
+  storageSet: false,
+  tty: null,
+  useLoadBalancer: null,
+  user: null,
+  volumes: null,
+  workingDirectory: null,
+}
+
+const imageConfig: DeployableImage = {
+  id: 'image',
+  name: 'image-name',
+  tag: 'latest',
+  order: 1,
+  labels: {},
+  configId: 'image-config-id',
+  config: {
+    secrets: [
+      {
+        id: 'image-required',
+        key: 'image-required',
+        required: true,
+      },
+      {
+        id: 'image-not-required',
+        key: 'image-not-required',
+        required: false,
+      },
+    ],
+  },
+  registryId: 'registry-id',
+  registry: null,
+  versionId: 'version-id',
+  createdAt: new Date(),
+  createdBy: 'user-id',
+  updatedAt: new Date(),
+  updatedBy: 'user-id',
+}
+
+const instanceConfig: DeployableInstance = {
+  id: 'instance',
+  configId: 'instance-config-id',
+  config: {
+    secrets: [
+      {
+        id: 'instance',
+        key: 'instance',
+        value: 'instance',
+        encrypted: true,
+        required: false,
+        publicKey: null,
+      },
+      {
+        id: 'instance-bundle-one-required',
+        key: 'bundle-one-required',
+        value: 'instance-bundle-one-required',
+        required: true,
+        encrypted: true,
+        publicKey: null,
+      },
+    ],
+  },
+  image: imageConfig,
+}
+
+const bundleOneConfig: DeployableConfigBundle = {
+  config: {
+    id: 'bundle-one-config-id',
+    secrets: [
+      {
+        id: 'bundle-one-required',
+        key: 'bundle-one-required',
+        required: true,
+      },
+    ],
+  },
+}
+
+const bundleTwoConfig: DeployableConfigBundle = {
+  config: {
+    id: 'bundle-two-config-id',
+    secrets: [
+      {
+        id: 'bundle-two-not-required',
+        key: 'bundle-two-not-required',
+        required: false,
+      },
+    ],
+  },
+}
+
+const deploymentConfig: DeployableDeployment = {
+  id: 'deployment',
+  nodeId: 'node-id',
+  prefix: 'prefix',
+  status: 'preparing',
+  tries: 0,
+  protected: false,
+  note: 'deployment-note',
+  configId: 'deployment-config-id',
+  config: {
+    secrets: [
+      {
+        id: 'deployment-image-required',
+        key: 'image-required',
+        value: 'deployment-image-required',
+        encrypted: true,
+        required: false,
+        publicKey: null,
+      },
+    ],
+  },
+  configBundles: [
+    {
+      configBundle: bundleOneConfig,
+    },
+    {
+      configBundle: bundleTwoConfig,
+    },
+  ],
+  versionId: 'version-id',
+  version: {
+    name: 'version-name',
+    type: 'incremental',
+  },
+  updatedAt: new Date(),
+  updatedBy: 'user-id',
+  createdAt: new Date(),
+  createdBy: 'user-id',
+  deployedAt: null,
+  deployedBy: null,
+  instances: [instanceConfig],
+}
+
+describe('start-deployment', () => {
+  describe('instanceConfigOf', () => {
+    it('should mix with deployment secrets', () => {
+      const merged = instanceConfigOf(deploymentConfig, instanceConfig)
+
+      const expected: ConcreteContainerConfigData = {
+        ...emptyConfig,
+        name: 'image-name',
+        secrets: [
+          {
+            id: 'instance',
+            key: 'instance',
+            value: 'instance',
+            encrypted: true,
+            required: false,
+            publicKey: null,
+          },
+          {
+            id: 'instance-bundle-one-required',
+            key: 'bundle-one-required',
+            value: 'instance-bundle-one-required',
+            required: true,
+            encrypted: true,
+            publicKey: null,
+          },
+          {
+            id: 'deployment-image-required',
+            key: 'image-required',
+            value: 'deployment-image-required',
+            encrypted: true,
+            required: false,
+            publicKey: null,
+          },
+        ],
+      }
+
+      expect(merged).toEqual(expected)
+    })
+  })
+})

--- a/web/crux/src/domain/start-deployment.ts
+++ b/web/crux/src/domain/start-deployment.ts
@@ -126,6 +126,13 @@ export const instanceConfigOf = (
     result.name = containerNameOfInstance(instance)
   }
 
+  // set empty secret values to null string
+  result.secrets?.forEach(it => {
+    if (!it.value) {
+      it.value = ''
+    }
+  })
+
   return result
 }
 
@@ -167,17 +174,25 @@ export const mergePrefixNeighborSecrets = (
       })
     })
 
-  currentSecrets.forEach(it => {
-    result.set(it.key, {
-      value: it.value,
-      deployedAt: null,
+  if (currentSecrets) {
+    currentSecrets.forEach(it => {
+      result.set(it.key, {
+        value: it.value,
+        deployedAt: null,
+      })
     })
-  })
+  }
 
-  const entries = [...result.entries()].map(entry => {
-    const [key, candidate] = entry
-    return [key, candidate.value]
-  })
+  const entries = [...result.entries()]
+    .filter(entry => {
+      const [, candidate] = entry
+      const { value } = candidate
+      return !!value
+    })
+    .map(entry => {
+      const [key, candidate] = entry
+      return [key, candidate.value]
+    })
 
   return Object.fromEntries(entries)
 }

--- a/web/crux/src/domain/start-deployment.ts
+++ b/web/crux/src/domain/start-deployment.ts
@@ -8,8 +8,8 @@ import {
 } from './container'
 import {
   mergeConfigsWithConcreteConfig,
-  mergeDeploymentConfigWithImageConfig,
   mergeInstanceConfigWithDeploymentConfig,
+  mergeInstanceConfigWithImageConfig,
 } from './container-merge'
 import { DeploymentWithConfig } from './deployment'
 import { ImageWithRegistry } from './image'
@@ -115,11 +115,11 @@ export const instanceConfigOf = (
   deployment: DeployableDeployment,
   instance: DeployableInstance,
 ): ConcreteContainerConfigData => {
-  // first we merge the deployment config with the image config to resolve secrets globally
-  const mergedDeploymentConfig = mergeDeploymentConfigWithImageConfig(deployment.config, instance.image.config)
+  // first we merge and override the instance config with the image config to have a concrete config intended by the user
+  const mergedInstanceConfig = mergeInstanceConfigWithImageConfig(instance.config, instance.image.config)
 
-  // then we merge and override the rest with the instance config
-  const result = mergeInstanceConfigWithDeploymentConfig(instance.config, mergedDeploymentConfig)
+  // then we merge the deployment config with the instance config to add additional config values and resolve the rest of the secrets
+  const result = mergeInstanceConfigWithDeploymentConfig(mergedInstanceConfig, deployment.config)
 
   // set defaults
   if (!result.name) {

--- a/web/crux/src/domain/start-deployment.ts
+++ b/web/crux/src/domain/start-deployment.ts
@@ -69,7 +69,7 @@ export const collectInvalidSecrets = (
 
       return {
         ...secret,
-        value: '',
+        value: null,
         encrypted: false,
         publicKey,
       }


### PR DESCRIPTION
- Instance config now overrides the image config values properly.
- Resetting a secret now sets its value to null, instead of encrypting a nullstring.

There was a case before, when the deployment config environment values had been applied to the instance config, thus image config required values wasn't fulfilled. That one should be resolved, as we now mix the deployment config with the instance config.