### PR TITLE
fix(cli): update traefik version to 2.11

### DIFF
--- a/golang/pkg/cli/container_defaults.go
+++ b/golang/pkg/cli/container_defaults.go
@@ -298,7 +298,7 @@ func GetTraefik(state *State, args *ArgsFlags) containerbuilder.Builder {
 	}
 
 	traefik := baseContainer(state.Ctx, args).
-		WithImage("docker.io/library/traefik:v2.9").
+		WithImage("docker.io/library/traefik:v2.11").
 		WithName(state.Containers.Traefik.Name).
 		WithRestartPolicy(container.RestartPolicyAlways).
 		WithNetworks([]string{state.SettingsFile.Network}).


### PR DESCRIPTION
There are some flaky errors with the 2.9 version, during `make upd`.