### PR TITLE
chore: upgrade traefik to the latest in the same major version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ export-full:
 	$(eval BUNDLEVER=$(or $(version),latest))
 	mv .env .env_bak || true
 	echo "DYO_VERSION=$(BUNDLEVER)" > .env
-	crane pull --platform=linux/amd64 docker.io/library/traefik:2.9 offline/traefik.tar
+	crane pull --platform=linux/amd64 docker.io/library/traefik:2.11 offline/traefik.tar
 	crane pull --platform=linux/amd64 docker.io/oryd/mailslurper:smtps-latest offline/mailslurper.tar
 	crane pull --platform=linux/amd64 ghcr.io/dyrector-io/dyrectorio/multi-database:1.0.4 offline/multidatabase.tar
 	crane pull --platform=linux/amd64 ghcr.io/dyrector-io/dyrectorio/web/kratos:latest offline/kratos.tar

--- a/distribution/compose/docker-compose.traefik-tls.yaml
+++ b/distribution/compose/docker-compose.traefik-tls.yaml
@@ -1,7 +1,7 @@
 services:
   traefik:
     container_name: traefik
-    image: docker.io/library/traefik:2.9
+    image: docker.io/library/traefik:2.11
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false

--- a/distribution/compose/docker-compose.traefik.yaml
+++ b/distribution/compose/docker-compose.traefik.yaml
@@ -1,7 +1,7 @@
 services:
   traefik:
     container_name: traefik
-    image: docker.io/library/traefik:2.9
+    image: docker.io/library/traefik:2.11
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false

--- a/golang/pkg/cli/container_defaults.go
+++ b/golang/pkg/cli/container_defaults.go
@@ -298,7 +298,7 @@ func GetTraefik(state *State, args *ArgsFlags) containerbuilder.Builder {
 	}
 
 	traefik := baseContainer(state.Ctx, args).
-		WithImage("docker.io/library/traefik:v2.9").
+		WithImage("docker.io/library/traefik:v2.11").
 		WithName(state.Containers.Traefik.Name).
 		WithRestartPolicy(container.RestartPolicyAlways).
 		WithNetworks([]string{state.SettingsFile.Network}).


### PR DESCRIPTION
It was necessary for more recent docker versions to keep functioning.