### PR TITLE
feat(crux-ui): ignore default tag in version order

### DIFF
--- a/web/crux-ui/locales/en/errors.json
+++ b/web/crux-ui/locales/en/errors.json
@@ -25,6 +25,7 @@
   "registryRateLimit": "Rate limit reached, please try again later",
   "registryUnauthorized": "Unauthorized",
   "deployRequiredSecrets": "The following instances have missing required secrets: {{instances}}",
+  "deployConfigBundleConflict": "Unresolved conflicts between config bundles in: {{keys}}",
 
   "yup": {
     "mixed": {

--- a/web/crux-ui/src/components/projects/project-versions-section.tsx
+++ b/web/crux-ui/src/components/projects/project-versions-section.tsx
@@ -8,17 +8,7 @@ import useTranslation from 'next-translate/useTranslation'
 import { QA_DIALOG_LABEL_SET_AS_DEFAULT } from 'quality-assurance'
 import VersionCard from './versions/version-card'
 
-const sortVersions = (one: Version, other: Version) => {
-  if (one.default) {
-    return -1
-  }
-
-  if (other.default) {
-    return 1
-  }
-
-  return sortDate(one.audit.updatedAt, other.audit.updatedAt)
-}
+const sortVersions = (one: Version, other: Version) => sortDate(one.audit.updatedAt, other.audit.updatedAt)
 
 type ProjectVersionsSectionProps = {
   projectId: string

--- a/web/crux-ui/src/components/projects/versions/images/edit-image-tags.tsx
+++ b/web/crux-ui/src/components/projects/versions/images/edit-image-tags.tsx
@@ -12,18 +12,15 @@ import useTranslation from 'next-translate/useTranslation'
 import { useEffect, useMemo, useState } from 'react'
 import TagSortToggle, { TagSortState } from './tag-sort-toggle'
 
-type ImageTagInputProps = {
+type SelectImageTagListProps = {
   disabled?: boolean
   selected: string
   onTagSelected: (tag: string) => void
-}
-
-type SelectImageTagListProps = ImageTagInputProps & {
   tags: RegistryImageTag[]
   loadingTags: boolean
 }
 
-const SelectImageTagList = (props: SelectImageTagListProps) => {
+const EditImageTags = (props: SelectImageTagListProps) => {
   const { disabled, tags, selected: propsSelected, onTagSelected, loadingTags } = props
 
   const { t } = useTranslation('images')
@@ -109,7 +106,7 @@ const SelectImageTagList = (props: SelectImageTagListProps) => {
           {selected ? null : <DyoMessage messageType="info" message={t('selectTag')} />}
           <div className="flex flex-col max-h-96 overflow-y-auto mt-2">
             {sortedItems.slice(pageStart, pageStart + pagination.pageSize).map((it, index) => (
-              <div className="flex flex-row gap-2 justify-between">
+              <div key={it.name} className="flex flex-row gap-2 justify-between">
                 <DyoRadioButton
                   key={`tag-${it}`}
                   disabled={disabled}
@@ -143,42 +140,6 @@ const SelectImageTagList = (props: SelectImageTagListProps) => {
       )}
     </div>
   )
-}
-
-const ImageTagInput = (props: ImageTagInputProps) => {
-  const { disabled, selected: propsSelected, onTagSelected } = props
-
-  const { t } = useTranslation('images')
-
-  const [selected, setSelected] = useState(propsSelected ?? '')
-
-  return (
-    <div className="flex flex-col mt-6 mb-8">
-      <DyoInput
-        label={t('tag')}
-        labelClassName="mb-2.5"
-        placeholder={t('tag')}
-        disabled={disabled}
-        value={selected}
-        onChange={e => {
-          const { value } = e.target
-          setSelected(value)
-          if (value?.length > 0) {
-            onTagSelected(value)
-          }
-        }}
-        messageType="info"
-        message={!selected.length && t('tagRequired')}
-      />
-
-      <p className="text-light-eased ml-4 mt-2">{t('uncheckedRegistryExplanation')}</p>
-    </div>
-  )
-}
-
-const EditImageTags = (props: SelectImageTagListProps) => {
-  const { tags } = props
-  return tags ? <SelectImageTagList {...props} /> : <ImageTagInput {...props} />
 }
 
 export default EditImageTags

--- a/web/crux-ui/src/components/projects/versions/images/image-tag-input.tsx
+++ b/web/crux-ui/src/components/projects/versions/images/image-tag-input.tsx
@@ -1,0 +1,42 @@
+import { DyoInput } from '@app/elements/dyo-input'
+import useTranslation from 'next-translate/useTranslation'
+import { useState } from 'react'
+
+type ImageTagInputProps = {
+  disabled?: boolean
+  value: string
+  onTagSelected: (tag: string) => void
+}
+
+const ImageTagInput = (props: ImageTagInputProps) => {
+  const { disabled, value: propsValue, onTagSelected } = props
+
+  const { t } = useTranslation('images')
+
+  const [selected, setSelected] = useState(propsValue ?? '')
+
+  return (
+    <div className="flex flex-col mt-6 mb-8">
+      <DyoInput
+        label={t('tag')}
+        labelClassName="mb-2.5"
+        placeholder={t('tag')}
+        disabled={disabled}
+        value={selected}
+        onChange={e => {
+          const { value } = e.target
+          setSelected(value)
+          if (value?.length > 0) {
+            onTagSelected(value)
+          }
+        }}
+        messageType="info"
+        message={!selected.length && t('tagRequired')}
+      />
+
+      <p className="text-light-eased ml-4 mt-2">{t('uncheckedRegistryExplanation')}</p>
+    </div>
+  )
+}
+
+export default ImageTagInput

--- a/web/crux-ui/src/components/projects/versions/version-view-list.tsx
+++ b/web/crux-ui/src/components/projects/versions/version-view-list.tsx
@@ -11,6 +11,7 @@ import { QA_DIALOG_LABEL_DELETE_IMAGE, QA_MODAL_LABEL_IMAGE_TAGS } from 'quality
 import { useState } from 'react'
 import EditImageTags from './images/edit-image-tags'
 import { VerionState, VersionActions, selectTagsOfImage } from './use-version-state'
+import ImageTagInput from './images/image-tag-input'
 
 interface VersionViewListProps {
   state: VerionState
@@ -50,6 +51,7 @@ const VersionViewList = (props: VersionViewListProps) => {
   }
 
   const imageTags = tagsModalTarget ? selectTagsOfImage(state, tagsModalTarget) : null
+  const onTagSelected = it => actions.selectTagForImage(tagsModalTarget, it)
 
   return (
     <>
@@ -135,12 +137,16 @@ const VersionViewList = (props: VersionViewListProps) => {
           onClose={() => setTagsModalTarget(null)}
           qaLabel={QA_MODAL_LABEL_IMAGE_TAGS}
         >
-          <EditImageTags
-            loadingTags={tagsModalTarget.registry.type === 'unchecked' ? false : !imageTags}
-            selected={tagsModalTarget.tag}
-            tags={tagsModalTarget.registry.type === 'unchecked' ? null : imageTags}
-            onTagSelected={it => actions.selectTagForImage(tagsModalTarget, it)}
-          />
+          {tagsModalTarget.registry.type === 'unchecked' ? (
+            <ImageTagInput value={tagsModalTarget.tag} onTagSelected={onTagSelected} />
+          ) : (
+            <EditImageTags
+              selected={tagsModalTarget.tag}
+              tags={imageTags ?? []}
+              loadingTags={!imageTags}
+              onTagSelected={onTagSelected}
+            />
+          )}
         </DyoModal>
       )}
     </>

--- a/web/crux-ui/src/hooks/use-deploy.ts
+++ b/web/crux-ui/src/hooks/use-deploy.ts
@@ -136,6 +136,15 @@ export const useDeploy = (opts: UseDeployOptions): UseDeployAction => {
         return
       }
 
+      if (property === 'configBundles') {
+        const keys = value as string[]
+        toast.error(t('errors:deployConfigBundleConflict', { keys }), {
+          className: toastClassName,
+        })
+
+        return
+      }
+
       if (property === 'protectedDeploymentId') {
         const confirmed = await confirm({
           qaLabel: QA_DIALOG_LABEL_DEPLOY_PROTECTED,

--- a/web/crux-ui/src/models/container-conflict.ts
+++ b/web/crux-ui/src/models/container-conflict.ts
@@ -293,7 +293,7 @@ const numbersConflict = (one: number, other: number): boolean => {
 }
 
 const objectsConflict = (one: object, other: object): boolean => {
-  if (typeof one !== 'object' || typeof one === null || typeof other !== 'object' || typeof other === null) {
+  if (typeof one !== 'object' || one === null || typeof other !== 'object' || other === null) {
     // some of them are null or uninterpretable
     return false
   }

--- a/web/crux/src/app/token/jwt-auth.guard.ts
+++ b/web/crux/src/app/token/jwt-auth.guard.ts
@@ -104,7 +104,7 @@ export default class JwtAuthGuard extends AuthGuard('jwt') {
     if (path !== '/api') {
       return
     }
-    const [paramName, token] = paramsString.split('=')
+    const [paramName, token] = paramsString?.split('=') ?? []
     if (paramName !== 'token' || !token) {
       return
     }

--- a/web/crux/src/domain/container-conflict.ts
+++ b/web/crux/src/domain/container-conflict.ts
@@ -293,7 +293,7 @@ const numbersConflict = (one: number, other: number): boolean => {
 }
 
 const objectsConflict = (one: object, other: object): boolean => {
-  if (typeof one !== 'object' || typeof one === null || typeof other !== 'object' || typeof other === null) {
+  if (typeof one !== 'object' || one === null || typeof other !== 'object' || other === null) {
     // some of them are null or uninterpretable
     return false
   }


### PR DESCRIPTION
- Ignore whether a version is default, when ordering them on the ui.
- Add better error messages for conflicting configs.
- Fix loading indicator during image tag selection.
- Fix metrics conflict detection.